### PR TITLE
[BE] feat: 채팅 서버 웹소켓 연동 및 테스트

### DIFF
--- a/backend/chat-server/build.gradle
+++ b/backend/chat-server/build.gradle
@@ -27,9 +27,22 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-
+	
+	// h2 데이터 베이스
 	implementation 'com.h2database:h2'
 
+	//Kafka
+	implementation 'org.springframework.kafka:spring-kafka'
+
+	// WebSocket
+	implementation 'org.springframework.boot:spring-boot-starter-websocket'
+
+	// STOMP
+	implementation 'org.webjars:stomp-websocket:2.3.4'
+
+	// SockJS
+	implementation 'org.webjars:sockjs-client:1.5.1'
+	
 	annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
 	implementation 'org.springframework.boot:spring-boot-starter-test'
 

--- a/backend/chat-server/src/main/java/com/smiletogether/chatserver/config/ChatConfig.java
+++ b/backend/chat-server/src/main/java/com/smiletogether/chatserver/config/ChatConfig.java
@@ -1,0 +1,25 @@
+package com.smiletogether.chatserver.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class ChatConfig implements WebSocketMessageBrokerConfigurer {
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        // 웹소켓이 handshake를 하기 위해 연결하는 endpoint
+        registry.addEndpoint("/ws")
+                .setAllowedOriginPatterns("*");
+//                .withSockJS();
+    }
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        // '/queue' prefix는 메시지가 1대1로 송신될 때,'/topic' prefix는 메시지가 1대다로 브로드캐스팅될 때
+        registry.enableSimpleBroker("/queue","/topic");
+        registry.setApplicationDestinationPrefixes("/app");
+    }
+}

--- a/backend/chat-server/src/main/java/com/smiletogether/chatserver/config/KafkaConfig.java
+++ b/backend/chat-server/src/main/java/com/smiletogether/chatserver/config/KafkaConfig.java
@@ -1,0 +1,41 @@
+package com.smiletogether.chatserver.config;
+
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.common.KafkaFuture;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+
+@Configuration
+public class KafkaConfig {
+
+    private static final String TOPIC_NAME = "test-topic";
+
+    @Bean
+    public NewTopic chatTopic(Environment env) {
+        String bootstrapServers = env.getProperty("spring.kafka.bootstrap-servers", "localhost:9094");
+
+        Map<String, Object> config = Map.of(
+                AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers
+        );
+
+        try (AdminClient adminClient = AdminClient.create(config)) {
+            KafkaFuture<Boolean> topicExists = adminClient.listTopics()
+                    .names()
+                    .thenApply(names -> names.contains(TOPIC_NAME));
+
+            if (topicExists.get()) {
+                return null; // 이미 존재하는 경우 새로 생성하지 않음
+            }
+        } catch (InterruptedException | ExecutionException e) {
+            throw new RuntimeException("Failed to check Kafka topic existence", e);
+        }
+
+        return new NewTopic(TOPIC_NAME, 1, (short) 1);
+    }
+}

--- a/backend/chat-server/src/main/java/com/smiletogether/chatserver/controller/ChannelChatController.java
+++ b/backend/chat-server/src/main/java/com/smiletogether/chatserver/controller/ChannelChatController.java
@@ -1,0 +1,33 @@
+package com.smiletogether.chatserver.controller;
+
+import com.smiletogether.chatserver.service.dto.MessageDto;
+import com.smiletogether.chatserver.service.ChatService;
+import com.smiletogether.chatserver.service.MessageProducer;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Slf4j
+@RequiredArgsConstructor
+public class ChannelChatController {
+
+    private final ChatService chatService;
+    private final MessageProducer messageProducer;
+
+    @MessageMapping("/hello")
+    @SendTo("/topic/greeting")
+    public void test(MessageDto message) {
+        log.info("Received message: {}", MessageDto.of(message));
+        chatService.testMessage(message);
+    }
+
+    @MessageMapping("/kafka-broad")
+    public void sendMessage(@RequestBody MessageDto message) {
+        log.info("Received WebSocket Message: {}", message);
+        messageProducer.sendMessage(message);
+    }
+}

--- a/backend/chat-server/src/main/java/com/smiletogether/chatserver/service/ChatService.java
+++ b/backend/chat-server/src/main/java/com/smiletogether/chatserver/service/ChatService.java
@@ -1,0 +1,19 @@
+package com.smiletogether.chatserver.service;
+
+import com.smiletogether.chatserver.service.dto.MessageDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class ChatService {
+    private final SimpMessagingTemplate simpMessagingTemplate;
+
+    public void testMessage(MessageDto message) {
+        log.info("Sending message: {}", MessageDto.of(message));
+        simpMessagingTemplate.convertAndSend("/topic/greeting", message);
+    }
+}

--- a/backend/chat-server/src/main/java/com/smiletogether/chatserver/service/MessageConsumer.java
+++ b/backend/chat-server/src/main/java/com/smiletogether/chatserver/service/MessageConsumer.java
@@ -1,0 +1,25 @@
+package com.smiletogether.chatserver.service;
+
+import com.smiletogether.chatserver.service.dto.MessageDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class MessageConsumer {
+
+    private final SimpMessagingTemplate messagingTemplate;
+
+    // 💡 Kafka 메시지를 MessageDto 객체로 직접 받을 수 있도록 변경
+    @KafkaListener(topics = "test-topic", groupId = "test-group")
+    public void consume(MessageDto message) {
+        log.info("Received Message from Kafka: {}", message);
+
+        // WebSocket을 통해 클라이언트에게 메시지 전송
+        messagingTemplate.convertAndSend("/topic/public", message);
+    }
+}

--- a/backend/chat-server/src/main/java/com/smiletogether/chatserver/service/MessageProducer.java
+++ b/backend/chat-server/src/main/java/com/smiletogether/chatserver/service/MessageProducer.java
@@ -1,0 +1,28 @@
+package com.smiletogether.chatserver.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.smiletogether.chatserver.service.dto.MessageDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class MessageProducer {
+
+    private final KafkaTemplate<String, String> kafkaTemplate; // JSON을 문자열로 전송
+    private final ObjectMapper objectMapper = new ObjectMapper(); // JSON 변환 객체
+    private static final String EXISTING_TOPIC = "test-topic";
+
+    public void sendMessage(MessageDto message) {
+        try {
+            String jsonMessage = objectMapper.writeValueAsString(message); // 객체 -> JSON 변환
+            log.info("Sending message to Kafka as JSON: {}", jsonMessage);
+            kafkaTemplate.send(EXISTING_TOPIC, jsonMessage); // JSON 문자열로 Kafka에 전송
+        } catch (Exception e) {
+            log.error("Failed to serialize message", e);
+        }
+    }
+}

--- a/backend/chat-server/src/main/java/com/smiletogether/chatserver/service/dto/MessageDto.java
+++ b/backend/chat-server/src/main/java/com/smiletogether/chatserver/service/dto/MessageDto.java
@@ -1,0 +1,13 @@
+package com.smiletogether.chatserver.service.dto;
+
+public record MessageDto(
+        Long userId,
+        String content
+) {
+    public static MessageDto of (MessageDto messageDto) {
+        return new MessageDto(
+                messageDto.userId,
+                messageDto.content
+        );
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

close #28 

## 📝작업 내용

- [x] 채팅 서버 웹소켓 연결
- [x] 채팅 서버 stomp 프로토콜로 메시지 보내기
- [x] 채팅 서버와 kafka 연동
- [x] 간단한 api 테스트

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/ae800814-88bb-463a-93e1-f9b88e704fd8)

## 💬리뷰 요구사항(선택)
- 스크린 샷은 웹소켓 통신 테스트 성공한 이미지입니다.

- 카프카는 다른 채팅 서버와의 동기화를 위해 브로드캐스트식으로 사용되어 서버간의 동기화를 담당합니다.

- **통신 과정(플로우)**
1. 클라이언트는 /app/chat.sendMessage 엔드포인트로 WebSocket 메시지를 전송한다.
서버가 Kafka에 메시지를 생산(Produce)

2. WebSocket으로 받은 메시지를 Kafka의 특정 토픽(예: chat-messages)으로 전송한다.
Kafka Consumer가 메시지를 소비(Consume)

3. Kafka Consumer는 해당 토픽에서 메시지를 읽고, 이를 WebSocket을 통해 클라이언트에게 전달한다.
WebSocket을 통해 클라이언트에게 메시지를 전파

4. SimpMessagingTemplate을 이용하여 구독 중인 클라이언트들에게 메시지를 전송한다.
클라이언트가 WebSocket을 통해 메시지를 수신

5. 클라이언트는 /topic/public과 같은 WebSocket 채널을 구독하여 메시지를 수신한다.
