### PR TITLE
[BE] feat: 멤버 서버 구현

### DIFF
--- a/backend/member-server/build.gradle
+++ b/backend/member-server/build.gradle
@@ -35,6 +35,8 @@ dependencies {
 
 	compileOnly 'org.projectlombok:lombok'
 
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
+
 	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 	annotationProcessor 'org.projectlombok:lombok'
 

--- a/backend/member-server/src/main/java/com/smiletoegether/memberserver/email/config/EmailConfig.java
+++ b/backend/member-server/src/main/java/com/smiletoegether/memberserver/email/config/EmailConfig.java
@@ -1,0 +1,69 @@
+package com.smiletoegether.memberserver.email.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import java.util.Properties;
+
+@Configuration
+public class EmailConfig {
+
+    @Value("${spring.mail.host}")
+    private String host;
+
+    @Value("${spring.mail.port}")
+    private int port;
+
+    @Value("${spring.mail.username}")
+    private String username;
+
+    @Value("${spring.mail.password}")
+    private String password;
+
+    @Value("${spring.mail.properties.mail.smtp.auth}")
+    private boolean auth;
+
+    @Value("${spring.mail.properties.mail.smtp.starttls.enable}")
+    private boolean starttlsEnable;
+
+    @Value("${spring.mail.properties.mail.smtp.starttls.required}")
+    private boolean starttlsRequired;
+
+    @Value("${spring.mail.properties.mail.smtp.connectiontimeout}")
+    private int connectionTimeout;
+
+    @Value("${spring.mail.properties.mail.smtp.timeout}")
+    private int timeout;
+
+    @Value("${spring.mail.properties.mail.smtp.writetimeout}")
+    private int writeTimeout;
+
+    @Bean
+    public JavaMailSender javaMailSender() {
+        JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+        mailSender.setHost(host);
+        mailSender.setPort(port);
+        mailSender.setUsername(username);
+        mailSender.setPassword(password);
+        mailSender.setDefaultEncoding("UTF-8");
+        mailSender.setJavaMailProperties(getMailProperties());
+
+        return mailSender;
+    }
+
+    private Properties getMailProperties() {
+        Properties properties = new Properties();
+        properties.put("mail.smtp.auth", auth);
+        properties.put("mail.smtp.starttls.enable", starttlsEnable);
+        properties.put("mail.smtp.starttls.required", starttlsRequired);
+        properties.put("mail.smtp.connectiontimeout", connectionTimeout);
+        properties.put("mail.smtp.timeout", timeout);
+        properties.put("mail.smtp.writetimeout", writeTimeout);
+
+        return properties;
+    }
+
+}

--- a/backend/member-server/src/main/java/com/smiletoegether/memberserver/email/service/EmailService.java
+++ b/backend/member-server/src/main/java/com/smiletoegether/memberserver/email/service/EmailService.java
@@ -50,4 +50,13 @@ public class EmailService {
             throw new RuntimeException(ERROR_MESSAGE);
         }
     }
+
+    // 이메일 전송 폼 생성
+    private SimpleMailMessage createEmailForm(String email, String title, String text) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(email);
+        message.setSubject(title);
+        message.setText(text);
+        return message;
+    }
 }

--- a/backend/member-server/src/main/java/com/smiletoegether/memberserver/email/service/EmailService.java
+++ b/backend/member-server/src/main/java/com/smiletoegether/memberserver/email/service/EmailService.java
@@ -1,0 +1,38 @@
+package com.smiletoegether.memberserver.email.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.Random;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class EmailService {
+    private static final String ERROR_MESSAGE = "인증코드 생성 실패";
+    private static final String EMAIL_TITLE_OF_VERIFICATION = "[ Smile Together ] 본인 인증을 위한 코드가 도착했어요! \uD83D\uDE0E";
+    private static final String EMAIL_SUCCESS_OF_VERIFICATION = "이메일로 인증코드를 전송했습니다.";
+
+    private final JavaMailSender emailSender;
+
+    // 인증 코드를 저장할 ConcurrentHashMap (이메일 -> 코드)
+    private final ConcurrentHashMap<String, String> verificationCodes = new ConcurrentHashMap<>();
+
+    // ScheduledExecutorService를 사용하여 일정 시간이 지나면 코드 삭제
+    private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
+
+    @Value("${spring.mail.auth-code-expiration-millis}")
+    private long authCodeExpirationMillis;
+}

--- a/backend/member-server/src/main/java/com/smiletoegether/memberserver/email/service/EmailService.java
+++ b/backend/member-server/src/main/java/com/smiletoegether/memberserver/email/service/EmailService.java
@@ -36,6 +36,18 @@ public class EmailService {
     @Value("${spring.mail.auth-code-expiration-millis}")
     private long authCodeExpirationMillis;
 
+    public String sendCode(String email) {
+        String code = createCode();
+        sendEmail(email, EMAIL_TITLE_OF_VERIFICATION, code);
+        verificationCodes.put(email, code);
+
+        scheduler.schedule(() -> {
+            verificationCodes.remove(email);
+        }, authCodeExpirationMillis, TimeUnit.MILLISECONDS);
+
+        return EMAIL_SUCCESS_OF_VERIFICATION;
+    }
+
     // 인증 코드 생성
     private String createCode() {
         int length = 6;

--- a/backend/member-server/src/main/java/com/smiletoegether/memberserver/email/service/EmailService.java
+++ b/backend/member-server/src/main/java/com/smiletoegether/memberserver/email/service/EmailService.java
@@ -35,7 +35,8 @@ public class EmailService {
 
     @Value("${spring.mail.auth-code-expiration-millis}")
     private long authCodeExpirationMillis;
-
+    
+    // 인증 코드 발송 및 메모리 저장
     public String sendCode(String email) {
         String code = createCode();
         sendEmail(email, EMAIL_TITLE_OF_VERIFICATION, code);
@@ -46,6 +47,16 @@ public class EmailService {
         }, authCodeExpirationMillis, TimeUnit.MILLISECONDS);
 
         return EMAIL_SUCCESS_OF_VERIFICATION;
+    }
+
+    // 인증 코드 확인
+    public boolean verifyCode(String email, String codeInput) {
+        String storedCode = verificationCodes.get(email);
+
+        if (storedCode == null) {
+            throw new RuntimeException("잘못된 이메일이거나 인증 코드가 만료되었습니다.");
+        }
+        return storedCode.equals(codeInput);
     }
 
     // 인증 코드 생성

--- a/backend/member-server/src/main/java/com/smiletoegether/memberserver/email/service/EmailService.java
+++ b/backend/member-server/src/main/java/com/smiletoegether/memberserver/email/service/EmailService.java
@@ -35,4 +35,19 @@ public class EmailService {
 
     @Value("${spring.mail.auth-code-expiration-millis}")
     private long authCodeExpirationMillis;
+
+    // 인증 코드 생성
+    private String createCode() {
+        int length = 6;
+        try {
+            Random random = SecureRandom.getInstanceStrong();
+            StringBuilder sb = new StringBuilder();
+            for (int i = 0; i < length; i++) {
+                sb.append(random.nextInt(10));
+            }
+            return sb.toString();
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(ERROR_MESSAGE);
+        }
+    }
 }

--- a/backend/member-server/src/main/java/com/smiletoegether/memberserver/email/service/EmailService.java
+++ b/backend/member-server/src/main/java/com/smiletoegether/memberserver/email/service/EmailService.java
@@ -59,4 +59,14 @@ public class EmailService {
         message.setText(text);
         return message;
     }
+
+    // 이메일 발송 메서드
+    private void sendEmail(String email, String title, String text) {
+        SimpleMailMessage emailForm = createEmailForm(email, title, text);
+        try {
+            emailSender.send(emailForm);
+        } catch (RuntimeException e) {
+            throw new RuntimeException("메일을 보낼 수 없습니다.");
+        }
+    }
 }

--- a/backend/member-server/src/main/java/com/smiletoegether/memberserver/member/controller/MemberController.java
+++ b/backend/member-server/src/main/java/com/smiletoegether/memberserver/member/controller/MemberController.java
@@ -1,0 +1,45 @@
+package com.smiletoegether.memberserver.member.controller;
+
+import com.smiletoegether.memberserver.member.service.MemberService;
+import com.smiletoegether.memberserver.member.service.dto.CertificationEmailRequest;
+import com.smiletoegether.memberserver.member.service.dto.CommonEmailCodeResponse;
+import com.smiletoegether.memberserver.member.service.dto.SignUpRequest;
+import com.smiletoegether.memberserver.member.service.dto.SignUpResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/member")
+@RequiredArgsConstructor
+public class MemberController {
+    private final MemberService memberService;
+    
+    // 이메일 중복 체크
+    @GetMapping("/check-email")
+    public ResponseEntity<String> verifyDuplication(@RequestParam String email) {
+        String responseMessage = memberService.verifyDuplication(email);
+        return ResponseEntity.ok(responseMessage);
+    }
+
+    // 인증 코드 이메일 발송
+    @PostMapping("/send-code")
+    public ResponseEntity<String> sendCode(@RequestParam String email) {
+        String responseMessage = memberService.sendCode(email);
+        return ResponseEntity.ok(responseMessage);
+    }
+
+    // 인증 코드 확인 (이메일 유효성 검사)
+    @PostMapping("/certificate-email")
+    public ResponseEntity<CommonEmailCodeResponse> certificateEmail(@RequestBody CertificationEmailRequest request) {
+        CommonEmailCodeResponse response = memberService.CertificateEmail(request);
+        return ResponseEntity.ok(response);
+    }
+
+    // 회원가입
+    @PostMapping("/sign-up")
+    public ResponseEntity<SignUpResponse> signUp(@RequestBody SignUpRequest signUpRequest) {
+        SignUpResponse response = memberService.SingUp(signUpRequest);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/backend/member-server/src/main/java/com/smiletoegether/memberserver/member/repository/MemberRepository.java
+++ b/backend/member-server/src/main/java/com/smiletoegether/memberserver/member/repository/MemberRepository.java
@@ -1,0 +1,12 @@
+package com.smiletoegether.memberserver.member.repository;
+
+import com.smiletoegether.memberserver.member.domain.Member;
+import org.springframework.data.repository.Repository;
+
+import java.util.Optional;
+
+public interface MemberRepository extends Repository<Member, Long> {
+    Optional<Member> findByEmail(String email);
+
+    Member save(Member member);
+}

--- a/backend/member-server/src/main/java/com/smiletoegether/memberserver/member/service/MemberService.java
+++ b/backend/member-server/src/main/java/com/smiletoegether/memberserver/member/service/MemberService.java
@@ -1,9 +1,12 @@
 package com.smiletoegether.memberserver.member.service;
 
 import com.smiletoegether.memberserver.email.service.EmailService;
+import com.smiletoegether.memberserver.member.domain.Member;
 import com.smiletoegether.memberserver.member.repository.MemberRepository;
 import com.smiletoegether.memberserver.member.service.dto.CertificationEmailRequest;
 import com.smiletoegether.memberserver.member.service.dto.CommonEmailCodeResponse;
+import com.smiletoegether.memberserver.member.service.dto.SignUpRequest;
+import com.smiletoegether.memberserver.member.service.dto.SignUpResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -47,5 +50,24 @@ public class MemberService {
         }
 
         return new CommonEmailCodeResponse("200", "이메일 인증 코드 확인이 완료되었습니다.");
+    }
+
+    // 회원가입
+    @Transactional
+    public SignUpResponse SingUp(SignUpRequest signUpRequest) {
+
+        Member member = initMember(signUpRequest);
+
+        return new SignUpResponse("201", "회원가입 완료", member);
+    }
+
+    private Member initMember(SignUpRequest signUpRequest) {
+        Member member = Member.builder()
+                .email(signUpRequest.email())
+                .username(signUpRequest.username())
+                .build();
+
+        memberRepository.save(member);
+        return member;
     }
 }

--- a/backend/member-server/src/main/java/com/smiletoegether/memberserver/member/service/MemberService.java
+++ b/backend/member-server/src/main/java/com/smiletoegether/memberserver/member/service/MemberService.java
@@ -2,6 +2,8 @@ package com.smiletoegether.memberserver.member.service;
 
 import com.smiletoegether.memberserver.email.service.EmailService;
 import com.smiletoegether.memberserver.member.repository.MemberRepository;
+import com.smiletoegether.memberserver.member.service.dto.CertificationEmailRequest;
+import com.smiletoegether.memberserver.member.service.dto.CommonEmailCodeResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -33,5 +35,17 @@ public class MemberService {
             throw new RuntimeException("중복 이메일");
         }
         return emailService.sendCode(email);
+    }
+
+    // 인증코드 확인
+    @Transactional
+    public CommonEmailCodeResponse CertificateEmail(CertificationEmailRequest certificationEmailRequest) {
+        boolean isVerified = emailService.verifyCode(certificationEmailRequest.email(), certificationEmailRequest.code());
+
+        if (!isVerified) {
+            return new CommonEmailCodeResponse("400", "이메일 인증 코드가 일치하지 않습니다.");
+        }
+
+        return new CommonEmailCodeResponse("200", "이메일 인증 코드 확인이 완료되었습니다.");
     }
 }

--- a/backend/member-server/src/main/java/com/smiletoegether/memberserver/member/service/MemberService.java
+++ b/backend/member-server/src/main/java/com/smiletoegether/memberserver/member/service/MemberService.java
@@ -1,0 +1,28 @@
+package com.smiletoegether.memberserver.member.service;
+
+import com.smiletoegether.memberserver.email.service.EmailService;
+import com.smiletoegether.memberserver.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class MemberService {
+    private final MemberRepository memberRepository;
+
+    private final EmailService emailService;
+
+    private static final String SIGN_UP_VALID_EMAIL = "사용 가능한 이메일입니다.";
+
+    // 이메일 중복 확인
+    @Transactional
+    public String verifyDuplication(String email) {
+        if (memberRepository.findByEmail(email).isPresent()) {
+            throw new RuntimeException("중복 이메일");
+        }
+        return SIGN_UP_VALID_EMAIL;
+    }
+}

--- a/backend/member-server/src/main/java/com/smiletoegether/memberserver/member/service/MemberService.java
+++ b/backend/member-server/src/main/java/com/smiletoegether/memberserver/member/service/MemberService.java
@@ -25,4 +25,13 @@ public class MemberService {
         }
         return SIGN_UP_VALID_EMAIL;
     }
+
+    // 인증 코드 발송
+    @Transactional
+    public String sendCode(String email) {
+        if (memberRepository.findByEmail(email).isPresent()) {
+            throw new RuntimeException("중복 이메일");
+        }
+        return emailService.sendCode(email);
+    }
 }

--- a/backend/member-server/src/main/java/com/smiletoegether/memberserver/member/service/dto/CertificationEmailRequest.java
+++ b/backend/member-server/src/main/java/com/smiletoegether/memberserver/member/service/dto/CertificationEmailRequest.java
@@ -1,0 +1,7 @@
+package com.smiletoegether.memberserver.member.service.dto;
+
+public record CertificationEmailRequest(
+    String email,
+    String code
+) {
+}

--- a/backend/member-server/src/main/java/com/smiletoegether/memberserver/member/service/dto/CommonEmailCodeResponse.java
+++ b/backend/member-server/src/main/java/com/smiletoegether/memberserver/member/service/dto/CommonEmailCodeResponse.java
@@ -1,0 +1,7 @@
+package com.smiletoegether.memberserver.member.service.dto;
+
+public record CommonEmailCodeResponse(
+        String code,
+        String message
+) {
+}

--- a/backend/member-server/src/main/java/com/smiletoegether/memberserver/member/service/dto/SignUpRequest.java
+++ b/backend/member-server/src/main/java/com/smiletoegether/memberserver/member/service/dto/SignUpRequest.java
@@ -1,0 +1,7 @@
+package com.smiletoegether.memberserver.member.service.dto;
+
+public record SignUpRequest(
+        String email,
+        String username) {
+
+}

--- a/backend/member-server/src/main/java/com/smiletoegether/memberserver/member/service/dto/SignUpResponse.java
+++ b/backend/member-server/src/main/java/com/smiletoegether/memberserver/member/service/dto/SignUpResponse.java
@@ -1,0 +1,10 @@
+package com.smiletoegether.memberserver.member.service.dto;
+
+import com.smiletoegether.memberserver.member.domain.Member;
+
+public record SignUpResponse(
+        String code,
+        String message,
+        Member data
+) {
+}

--- a/backend/member-server/src/main/resources/db/data.sql
+++ b/backend/member-server/src/main/resources/db/data.sql
@@ -1,0 +1,16 @@
+INSERT INTO member (username, email, created_at, updated_at) VALUES
+        ('test1', 'test1@example.com', NOW(), NOW()),
+        ('test2', 'test2@example.com', NOW(), NOW()),
+        ('test3', 'test3@example.com', NOW(), NOW()),
+        ('test4', 'test4@example.com', NOW(), NOW()),
+        ('test5', 'test5@example.com', NOW(), NOW()),
+        ('test6', 'test6@example.com', NOW(), NOW()),
+        ('test7', 'test7@example.com', NOW(), NOW()),
+        ('test8', 'test8@example.com', NOW(), NOW()),
+        ('test9', 'test9@example.com', NOW(), NOW()),
+        ('test10', 'test10@example.com', NOW(), NOW()),
+        ('test11', 'test11@example.com', NOW(), NOW()),
+        ('test12', 'test12@example.com', NOW(), NOW()),
+        ('test13', 'test13@example.com', NOW(), NOW()),
+        ('test14', 'test14@example.com', NOW(), NOW()),
+        ('test15', 'test15@example.com', NOW(), NOW());


### PR DESCRIPTION
## #️⃣연관된 이슈

close #34 

## 📝작업 내용
- [x] 사용자 정보 관리 (회원 가입) 
- [x] 이메일 인증 기능 (유저 확인)  

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/2bdbf0c0-b848-4985-97ad-c6df89bd39df)

## 💬리뷰 요구사항(선택)
- 이메일 인증 서버를 현재는 멤버서버와 통합되어 있는데, 이에 대해 생각해볼 필요가 있을 것 같습니다.
- 새벽에 이메일 만들려고 하니, 이미 만들어져 있다해서 이메일 공유 부탁드립니다.
- 이메일 인증 서버의 경우에 지금 메모리에 저장하고 있지만,  redis를 사용한 Nosql 기반의 캐싱 기능으로 고도화 시킬 예정입니다.
- 이메일 발송 및 인증의 경우 공통적으로 쓰이는 기능이기 때문에 모듈로 관리하거나 혹은 자체적인 서버로 관리해야할 가능성에 대해 생각해볼만 합니다.
