### PR TITLE
[BE] feat: 채널 CRUD 구현 #77

### DIFF
--- a/backend/space-server/src/app.module.ts
+++ b/backend/space-server/src/app.module.ts
@@ -3,9 +3,10 @@ import { ConfigModule } from '@nestjs/config';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { WorkspaceModule } from './workspace/workspace.module';
+import { ChannelModule } from './channel/channel.module';
 
 @Module({
-  imports: [ConfigModule.forRoot(), WorkspaceModule],
+  imports: [ConfigModule.forRoot(), WorkspaceModule, ChannelModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/backend/space-server/src/channel/channel.controller.ts
+++ b/backend/space-server/src/channel/channel.controller.ts
@@ -1,0 +1,14 @@
+import { Controller, Get, UseGuards } from '@nestjs/common';
+import { ChannelService } from './channel.service';
+import { AuthGuard } from 'src/guards/auth.guard';
+
+@Controller('api/channel')
+@UseGuards(AuthGuard)
+export class ChannelController {
+  constructor(private readonly channelService: ChannelService) {}
+
+  @Get()
+  getChannel(): string {
+    return 'get api/channel';
+  }
+}

--- a/backend/space-server/src/channel/channel.controller.ts
+++ b/backend/space-server/src/channel/channel.controller.ts
@@ -39,4 +39,12 @@ export class ChannelController {
   ): Promise<ChannelDetailsDto> {
     return this.channelService.getChannelById(channelId);
   }
+
+  @Post(':channelId/join')
+  async joinChannel(
+    @UserId() userId: string,
+    @Param('channelId') channelId: string,
+  ): Promise<any> {
+    return this.channelService.joinChannel(userId, channelId);
+  }
 }

--- a/backend/space-server/src/channel/channel.controller.ts
+++ b/backend/space-server/src/channel/channel.controller.ts
@@ -1,8 +1,11 @@
-import { Controller, Get, UseGuards } from '@nestjs/common';
+import { Body, Controller, Get, Post, UseGuards } from '@nestjs/common';
 import { ChannelService } from './channel.service';
 import { AuthGuard } from 'src/guards/auth.guard';
+import { ChannelResponseDto } from './dto/channel-response.dto';
+import { CreateChannelDto } from './dto/create-channel.dto';
+import { UserId } from 'src/decorators/user-id.decorator';
 
-@Controller('api/channel')
+@Controller('api/channels')
 @UseGuards(AuthGuard)
 export class ChannelController {
   constructor(private readonly channelService: ChannelService) {}
@@ -10,5 +13,13 @@ export class ChannelController {
   @Get()
   getChannel(): string {
     return 'get api/channel';
+  }
+
+  @Post()
+  async createChannel(
+    @Body() createChannelDto: CreateChannelDto,
+    @UserId() userId: string,
+  ): Promise<ChannelResponseDto> {
+    return this.channelService.createChannel(userId, createChannelDto);
   }
 }

--- a/backend/space-server/src/channel/channel.controller.ts
+++ b/backend/space-server/src/channel/channel.controller.ts
@@ -63,4 +63,12 @@ export class ChannelController {
   ): Promise<any> {
     return await this.channelService.leaveChannel(channelId, userId);
   }
+
+  @Delete(':channel_id')
+  async deleteChannel(
+    @UserId() userId: string,
+    @Param('channel_id') channelId: string,
+  ): Promise<any> {
+    return await this.channelService.deleteChannel(channelId, userId);
+  }
 }

--- a/backend/space-server/src/channel/channel.controller.ts
+++ b/backend/space-server/src/channel/channel.controller.ts
@@ -1,4 +1,12 @@
-import { Body, Controller, Get, Param, Post, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
 import { ChannelService } from './channel.service';
 import { AuthGuard } from 'src/guards/auth.guard';
 import { UserId } from 'src/decorators/user-id.decorator';
@@ -46,5 +54,13 @@ export class ChannelController {
     @Param('channelId') channelId: string,
   ): Promise<any> {
     return this.channelService.joinChannel(userId, channelId);
+  }
+
+  @Delete(':channel_id/leave')
+  async leaveChannel(
+    @UserId() userId: string,
+    @Param('channel_id') channelId: string,
+  ): Promise<any> {
+    return await this.channelService.leaveChannel(channelId, userId);
   }
 }

--- a/backend/space-server/src/channel/channel.controller.ts
+++ b/backend/space-server/src/channel/channel.controller.ts
@@ -1,9 +1,10 @@
-import { Body, Controller, Get, Post, UseGuards } from '@nestjs/common';
+import { Body, Controller, Get, Param, Post, UseGuards } from '@nestjs/common';
 import { ChannelService } from './channel.service';
 import { AuthGuard } from 'src/guards/auth.guard';
+import { UserId } from 'src/decorators/user-id.decorator';
 import { ChannelResponseDto } from './dto/channel-response.dto';
 import { CreateChannelDto } from './dto/create-channel.dto';
-import { UserId } from 'src/decorators/user-id.decorator';
+import { WorkspaceChannelDto } from './dto/workspace-channel.dto';
 
 @Controller('api/channels')
 @UseGuards(AuthGuard)
@@ -21,5 +22,13 @@ export class ChannelController {
     @UserId() userId: string,
   ): Promise<ChannelResponseDto> {
     return this.channelService.createChannel(userId, createChannelDto);
+  }
+
+  @Get('workspaces/:workspaceId')
+  async getChannelsByUser(
+    @UserId() userId: string,
+    @Param('workspaceId') workspaceId: string,
+  ): Promise<WorkspaceChannelDto> {
+    return this.channelService.getChannelsByUser(userId, workspaceId);
   }
 }

--- a/backend/space-server/src/channel/channel.controller.ts
+++ b/backend/space-server/src/channel/channel.controller.ts
@@ -5,6 +5,7 @@ import { UserId } from 'src/decorators/user-id.decorator';
 import { ChannelResponseDto } from './dto/channel-response.dto';
 import { CreateChannelDto } from './dto/create-channel.dto';
 import { WorkspaceChannelDto } from './dto/workspace-channel.dto';
+import { ChannelDetailsDto } from './dto/channel-detail.dto';
 
 @Controller('api/channels')
 @UseGuards(AuthGuard)
@@ -13,7 +14,7 @@ export class ChannelController {
 
   @Get()
   getChannel(): string {
-    return 'get api/channel';
+    return 'Hello Channel API!';
   }
 
   @Post()
@@ -30,5 +31,12 @@ export class ChannelController {
     @Param('workspaceId') workspaceId: string,
   ): Promise<WorkspaceChannelDto> {
     return this.channelService.getChannelsByUser(userId, workspaceId);
+  }
+
+  @Get(':channelId')
+  async getChannelById(
+    @Param('channelId') channelId: string,
+  ): Promise<ChannelDetailsDto> {
+    return this.channelService.getChannelById(channelId);
   }
 }

--- a/backend/space-server/src/channel/channel.module.ts
+++ b/backend/space-server/src/channel/channel.module.ts
@@ -1,0 +1,18 @@
+import { Module } from '@nestjs/common';
+import { JwtModule } from '@nestjs/jwt';
+import { PrismaModule } from 'prisma/prisma.module';
+import { ChannelController } from './channel.controller';
+import { AuthGuard } from 'src/guards/auth.guard';
+import { ChannelService } from './channel.service';
+
+@Module({
+  imports: [
+    PrismaModule,
+    JwtModule.register({
+      signOptions: { expiresIn: '1h' },
+    }),
+  ],
+  controllers: [ChannelController],
+  providers: [ChannelService, AuthGuard],
+})
+export class ChannelModule {}

--- a/backend/space-server/src/channel/channel.service.ts
+++ b/backend/space-server/src/channel/channel.service.ts
@@ -20,8 +20,7 @@ export class ChannelService {
     userId: string,
     createChannelDto: CreateChannelDto,
   ): Promise<ChannelResponseDto> {
-    const { workspaceId, channelName, description, isPrivate } =
-      createChannelDto;
+    const { workspaceId, name, description, isPrivate } = createChannelDto;
 
     const workspaceUser = await this.prismaService.workspaceUser.findUnique({
       where: {
@@ -39,7 +38,7 @@ export class ChannelService {
     const newChannel = await this.prismaService.channel.create({
       data: {
         workspace_id: workspaceId,
-        name: channelName,
+        name: name,
         description: description,
         is_private: isPrivate,
       },
@@ -55,7 +54,7 @@ export class ChannelService {
 
     const channelResponse: ChannelResponseDto = {
       channelId: newChannel.channel_id,
-      channelName: newChannel.name,
+      name: newChannel.name,
       description: newChannel.description || '',
       isPrivate: newChannel.is_private,
       createdAt: newChannel.created_at,

--- a/backend/space-server/src/channel/channel.service.ts
+++ b/backend/space-server/src/channel/channel.service.ts
@@ -195,8 +195,8 @@ export class ChannelService {
 
     if (channelUser) {
       return {
-        message: 'User is already a member of the channel.',
         channelId: channelId,
+        message: 'User is already a member of the channel.',
       };
     }
 
@@ -299,7 +299,7 @@ export class ChannelService {
     });
 
     return {
-      channel_id: deletedChannel.channel_id,
+      channelId: deletedChannel.channel_id,
       status: 'channel deleted',
     };
   }

--- a/backend/space-server/src/channel/channel.service.ts
+++ b/backend/space-server/src/channel/channel.service.ts
@@ -1,0 +1,7 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from 'prisma/prisma.service';
+
+@Injectable()
+export class ChannelService {
+  constructor(private readonly prismaService: PrismaService) {}
+}

--- a/backend/space-server/src/channel/channel.service.ts
+++ b/backend/space-server/src/channel/channel.service.ts
@@ -1,7 +1,59 @@
-import { Injectable } from '@nestjs/common';
+import { ForbiddenException, Injectable } from '@nestjs/common';
 import { PrismaService } from 'prisma/prisma.service';
+import { ChannelResponseDto } from './dto/channel-response.dto';
+import { CreateChannelDto } from './dto/create-channel.dto';
 
 @Injectable()
 export class ChannelService {
   constructor(private readonly prismaService: PrismaService) {}
+
+  async createChannel(
+    userId: string,
+    createChannelDto: CreateChannelDto,
+  ): Promise<ChannelResponseDto> {
+    const { workspaceId, channelName, description, isPrivate } =
+      createChannelDto;
+
+    const workspaceUser = await this.prismaService.workspaceUser.findUnique({
+      where: {
+        user_id_workspace_id: {
+          user_id: userId,
+          workspace_id: workspaceId,
+        },
+      },
+    });
+
+    if (!workspaceUser) {
+      throw new ForbiddenException(
+        '해당 워크스페이스에 소속되지 않은 사용자입니다',
+      );
+    }
+
+    const newChannel = await this.prismaService.channel.create({
+      data: {
+        workspace_id: workspaceId,
+        name: channelName,
+        description: description,
+        is_private: isPrivate,
+      },
+    });
+
+    await this.prismaService.channelUser.create({
+      data: {
+        user_id: userId,
+        channel_id: newChannel.channel_id,
+        channel_role: 'admin',
+      },
+    });
+
+    const channelResponse: ChannelResponseDto = {
+      channelId: newChannel.channel_id,
+      channelName: newChannel.name,
+      description: newChannel.description || '',
+      isPrivate: newChannel.is_private,
+      createdAt: newChannel.created_at,
+    };
+
+    return channelResponse;
+  }
 }

--- a/backend/space-server/src/channel/channel.service.ts
+++ b/backend/space-server/src/channel/channel.service.ts
@@ -128,6 +128,7 @@ export class ChannelService {
       where: { channel_id: channelId },
       select: {
         user_id: true,
+        channel_role: true,
       },
     });
 
@@ -143,20 +144,40 @@ export class ChannelService {
       },
     });
 
+    const adminUserId = channelUsers.find(
+      (user) => user.channel_role === 'admin',
+    )?.user_id;
+    const adminUser = members.find((member) => member.user_id === adminUserId);
+
+    const mappedAdminUser = {
+      userId: adminUser.user_id,
+      nickname: adminUser.profile_name,
+      displayName: '',
+      profileImage: adminUser.profile_image,
+      position: '',
+      isActive: true,
+      statusMessage: '',
+    };
+
     const mappedMembers = members.map((member) => ({
       userId: member.user_id,
       nickname: member.profile_name,
+      displayName: '',
       profileImage: member.profile_image,
+      position: '',
+      isActive: true,
+      statusMessage: '',
     }));
 
     return {
       channelId: channel.channel_id,
-      name: channel.name,
+      channelName: channel.name,
+      createdBy: mappedAdminUser,
       description: channel.description,
       isPrivate: channel.is_private,
+      totalMembers: mappedMembers.length,
       members: mappedMembers,
       createdAt: channel.created_at.toISOString(),
-      lastActiveAt: channel.updated_at.toISOString(),
     };
   }
 

--- a/backend/space-server/src/channel/dto/channel-detail.dto.ts
+++ b/backend/space-server/src/channel/dto/channel-detail.dto.ts
@@ -1,0 +1,15 @@
+export class ChannelDetailsDto {
+  channelId: string;
+  name: string;
+  description: string | null;
+  isPrivate: boolean;
+  members: MemberDto[];
+  createdAt: string;
+  lastActiveAt: string;
+}
+
+export class MemberDto {
+  userId: string;
+  nickname: string;
+  profileImage: string;
+}

--- a/backend/space-server/src/channel/dto/channel-detail.dto.ts
+++ b/backend/space-server/src/channel/dto/channel-detail.dto.ts
@@ -1,15 +1,20 @@
 export class ChannelDetailsDto {
   channelId: string;
-  name: string;
+  channelName: string;
   description: string | null;
-  isPrivate: boolean;
-  members: MemberDto[];
   createdAt: string;
-  lastActiveAt: string;
+  createdBy: MemberDto;
+  isPrivate: boolean;
+  totalMembers: number;
+  members: MemberDto[];
 }
 
 export class MemberDto {
   userId: string;
   nickname: string;
+  displayName: string | null;
   profileImage: string;
+  position: string | null;
+  isActive: boolean;
+  statusMessage: string | null;
 }

--- a/backend/space-server/src/channel/dto/channel-response.dto.ts
+++ b/backend/space-server/src/channel/dto/channel-response.dto.ts
@@ -1,6 +1,6 @@
 export class ChannelResponseDto {
   channelId: string;
-  channelName: string;
+  name: string;
   description: string;
   isPrivate: boolean;
   createdAt: Date;

--- a/backend/space-server/src/channel/dto/channel-response.dto.ts
+++ b/backend/space-server/src/channel/dto/channel-response.dto.ts
@@ -1,0 +1,7 @@
+export class ChannelResponseDto {
+  channelId: string;
+  channelName: string;
+  description: string;
+  isPrivate: boolean;
+  createdAt: Date;
+}

--- a/backend/space-server/src/channel/dto/create-channel.dto.ts
+++ b/backend/space-server/src/channel/dto/create-channel.dto.ts
@@ -1,0 +1,18 @@
+import { IsString, IsNotEmpty } from 'class-validator';
+
+export class CreateChannelDto {
+  @IsString()
+  @IsNotEmpty()
+  workspaceId: string;
+
+  @IsString()
+  @IsNotEmpty()
+  channelName: string;
+
+  @IsString()
+  @IsNotEmpty()
+  description: string;
+
+  @IsNotEmpty()
+  isPrivate: boolean;
+}

--- a/backend/space-server/src/channel/dto/create-channel.dto.ts
+++ b/backend/space-server/src/channel/dto/create-channel.dto.ts
@@ -7,7 +7,7 @@ export class CreateChannelDto {
 
   @IsString()
   @IsNotEmpty()
-  channelName: string;
+  name: string;
 
   @IsString()
   @IsNotEmpty()

--- a/backend/space-server/src/channel/dto/workspace-channel.dto.ts
+++ b/backend/space-server/src/channel/dto/workspace-channel.dto.ts
@@ -1,0 +1,9 @@
+export class WorkspaceChannelDto {
+  channels: ChannelItemDto[];
+}
+
+export class ChannelItemDto {
+  channelId: string;
+  name: string;
+  isPrivate: boolean;
+}

--- a/backend/space-server/src/main.ts
+++ b/backend/space-server/src/main.ts
@@ -4,6 +4,6 @@ import { AppModule } from './app.module';
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   app.enableCors();
-  await app.listen(process.env.PORT ?? 3000);
+  await app.listen(process.env.PORT ?? 8090);
 }
 bootstrap();

--- a/backend/space-server/src/workspace/dto/create-workspace.dto.ts
+++ b/backend/space-server/src/workspace/dto/create-workspace.dto.ts
@@ -3,20 +3,20 @@ import { IsString, IsOptional, IsArray, IsNotEmpty } from 'class-validator';
 export class CreateWorkspaceDto {
   @IsString()
   @IsNotEmpty()
-  workspace_name: string;
+  workspaceName: string;
 
   @IsString()
   @IsNotEmpty()
-  owner_id: string;
+  ownerId: string;
 
   @IsString()
   @IsNotEmpty()
-  user_name: string;
+  userName: string;
 
   @IsOptional()
-  profile_image?: string;
+  profileImage?: string;
 
   @IsArray()
   @IsString()
-  invite_user_list: string[];
+  inviteUserList: string[];
 }

--- a/backend/space-server/src/workspace/dto/delete-workspace.dto.ts
+++ b/backend/space-server/src/workspace/dto/delete-workspace.dto.ts
@@ -1,4 +1,4 @@
 export class WorkspaceDeleteResponseDto {
-  workspace_id: string;
+  workspaceId: string;
   status: string;
 }

--- a/backend/space-server/src/workspace/dto/invite-workspace.dto.ts
+++ b/backend/space-server/src/workspace/dto/invite-workspace.dto.ts
@@ -4,5 +4,5 @@ export class InviteWorkspaceDto {
   @IsArray()
   @IsString()
   @IsNotEmpty()
-  invite_user_list: string[];
+  inviteUserList: string[];
 }

--- a/backend/space-server/src/workspace/dto/search-workspace.dto.ts
+++ b/backend/space-server/src/workspace/dto/search-workspace.dto.ts
@@ -1,7 +1,7 @@
 export class WorkspaceSearchItemDto {
-  workspace_id: string;
+  workspaceId: string;
   name: string;
-  owner_id: string;
+  ownerId: string;
   nickname: string;
 }
 

--- a/backend/space-server/src/workspace/dto/workspace-detail.dto.ts
+++ b/backend/space-server/src/workspace/dto/workspace-detail.dto.ts
@@ -1,15 +1,15 @@
 export class WorkspaceUserDto {
-  user_id: string;
+  userId: string;
   nickname: string;
   role: string;
 }
 
 export class WorkspaceDetailResponseDto {
-  workspace_id: string;
+  workspaceId: string;
   name: string;
-  owner_id: string;
-  profile_image: string;
+  ownerId: string;
+  profileImage: string;
   users: WorkspaceUserDto[];
-  created_at: Date;
-  updated_at: Date;
+  createdAt: Date;
+  updatedAt: Date;
 }

--- a/backend/space-server/src/workspace/workspace.service.ts
+++ b/backend/space-server/src/workspace/workspace.service.ts
@@ -48,13 +48,13 @@ export class WorkspaceService {
       userWorkspaces: {
         email: 'temp@email.com',
         workspaces: workspaces.map((workspace) => ({
-          workspace_id: workspace.workspace_id,
+          workspaceId: workspace.workspace_id,
           name: workspace.name,
-          profile_image: workspace.workspace_image,
-          member_count: workspace._count.WorkspaceUser,
-          workspace_members: workspace.WorkspaceUser.map((member) => ({
-            user_id: member.user_id,
-            profile_image: member.profile_image,
+          profileImage: workspace.workspace_image,
+          memberCount: workspace._count.WorkspaceUser,
+          workspaceMembers: workspace.WorkspaceUser.map((member) => ({
+            userId: member.user_id,
+            profileImage: member.profile_image,
           })),
         })),
       },
@@ -64,13 +64,8 @@ export class WorkspaceService {
   async createWorkspace(
     createWorkspaceDto: CreateWorkspaceDto,
   ): Promise<WorkspaceResponseDto> {
-    const {
-      workspace_name,
-      owner_id,
-      user_name,
-      profile_image,
-      invite_user_list,
-    } = createWorkspaceDto;
+    const { workspaceName, ownerId, userName, profileImage, inviteUserList } =
+      createWorkspaceDto;
 
     const inviteResults = {
       success: [],
@@ -81,8 +76,8 @@ export class WorkspaceService {
       // 워크스페이스 생성
       const workspace = await prisma.workspace.create({
         data: {
-          name: workspace_name,
-          workspace_image: profile_image || 'default.jpg',
+          name: workspaceName,
+          workspace_image: profileImage || 'default.jpg',
         },
       });
 
@@ -90,10 +85,10 @@ export class WorkspaceService {
       await prisma.workspaceUser.create({
         data: {
           workspace_id: workspace.workspace_id,
-          user_id: owner_id,
+          user_id: ownerId,
           role: 'admin',
-          profile_name: user_name,
-          profile_image: profile_image || 'default.jpg',
+          profile_name: userName,
+          profile_image: profileImage || 'default.jpg',
         },
       });
 
@@ -111,13 +106,13 @@ export class WorkspaceService {
       await prisma.channelUser.create({
         data: {
           channel_id: defaultChannel.channel_id,
-          user_id: owner_id,
+          user_id: ownerId,
           channel_role: 'admin',
         },
       });
 
       // 초대된 사용자들 처리
-      for (const userId of invite_user_list) {
+      for (const userId of inviteUserList) {
         try {
           // 워크스페이스 멤버로 추가
           await prisma.workspaceUser.create({
@@ -149,10 +144,10 @@ export class WorkspaceService {
       // response
       return {
         workspaceId: workspace.workspace_id,
-        name: workspace_name,
-        creator: owner_id,
+        name: workspaceName,
+        creator: ownerId,
         defaultChannel: defaultChannel.channel_id,
-        profileImage: profile_image || 'default.jpg',
+        profileImage: profileImage || 'default.jpg',
         inviteResults,
         createdAt: workspace.created_at,
       };
@@ -181,9 +176,9 @@ export class WorkspaceService {
 
     return {
       workspaces: workspaces.map((workspace) => ({
-        workspace_id: workspace.workspace_id,
+        workspaceId: workspace.workspace_id,
         name: workspace.name,
-        owner_id: workspace.WorkspaceUser[0].user_id,
+        ownerId: workspace.WorkspaceUser[0].user_id,
         nickname: workspace.WorkspaceUser[0].profile_name,
       })),
     };
@@ -193,7 +188,7 @@ export class WorkspaceService {
     workspaceId: string,
     inviteWorkspaceDto: InviteWorkspaceDto,
   ) {
-    const { invite_user_list } = inviteWorkspaceDto;
+    const { inviteUserList } = inviteWorkspaceDto;
 
     const inviteResults = {
       success: [],
@@ -230,7 +225,7 @@ export class WorkspaceService {
 
       const existingMemberIds = existingMembers.map((member) => member.user_id);
 
-      for (const userId of invite_user_list) {
+      for (const userId of inviteUserList) {
         try {
           if (existingMemberIds.includes(userId)) {
             inviteResults.failed.push(userId);
@@ -300,18 +295,18 @@ export class WorkspaceService {
     }
 
     return {
-      workspace_id: workspace.workspace_id,
+      workspaceId: workspace.workspace_id,
       name: workspace.name,
-      owner_id: workspace.WorkspaceUser.find((user) => user.role === 'admin')
+      ownerId: workspace.WorkspaceUser.find((user) => user.role === 'admin')
         ?.user_id,
-      profile_image: workspace.workspace_image,
+      profileImage: workspace.workspace_image,
       users: workspace.WorkspaceUser.map((user) => ({
-        user_id: user.user_id,
+        userId: user.user_id,
         nickname: user.profile_name,
         role: user.role,
       })),
-      created_at: workspace.created_at,
-      updated_at: workspace.updated_at,
+      createdAt: workspace.created_at,
+      updatedAt: workspace.updated_at,
     };
   }
 
@@ -350,7 +345,7 @@ export class WorkspaceService {
     });
 
     return {
-      workspace_id: deletedWorkspace.workspace_id,
+      workspaceId: deletedWorkspace.workspace_id,
       status: 'workspace deleted',
     };
   }


### PR DESCRIPTION
## #️⃣연관된 이슈

> - close #77

## 📝작업 내용

> 작업한 내용을 작성해주세요.

- 채널 생성 api 구현
- 유저의 채널 조회 api 구현
- 채널 id를 통한 채널 조회 api 구현
- 채널 참여 api 구현
- 채널 삭제 api 구현
- 채널 나가기 api 구현

### 스크린샷 (선택)
![createChannel](https://github.com/user-attachments/assets/724df276-d5b7-470f-8c4e-a4134e1d5911)
![getChannelsByUser](https://github.com/user-attachments/assets/19dc49f3-ac94-4581-aed6-bc31d2b4a44f)
![joinChannel](https://github.com/user-attachments/assets/daa1359e-575b-4651-864b-23d2a816b055)
![leaveChannel](https://github.com/user-attachments/assets/08ed9c68-a536-4f7c-8914-69c18db2ffdd)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

중복되어서 비효율적인 부분이 많은데 연동이랑 인증 부분이 급하니
인증 서버 작업하면서 이슈 새로 파서 같이 리팩토링 작업을 해야할 것 같습니다..!!

처음에 DB 설계할 때 workspace 별 유저 position, statusMessage는 고려를 하지 않았어서 채팅방 정보 api에서는 빈 스트링만 반환하도록 해뒀는데 이 부분도 천천히 다른 작업 같이하면서 고치겠습니다

+ 포트번호 8090으로 변경했습니다!
