### PR TITLE
[BE] bug: 포트 변경에 따른 도커 파일 수정

### DIFF
--- a/backend/space-server/Dockerfile
+++ b/backend/space-server/Dockerfile
@@ -10,4 +10,4 @@ RUN pnpm install
 
 COPY . .
 
-EXPOSE 3000
+EXPOSE 8090

--- a/config/docker-compose-space-server.yml
+++ b/config/docker-compose-space-server.yml
@@ -20,7 +20,7 @@ services:
     environment:
       DATABASE_URL: postgresql://myuser:mypassword@space_db_postgres:5432/mydatabase
     ports:
-      - "3000:3000"
+      - "8090:8090"
     depends_on:
       - postgres
     command: >


### PR DESCRIPTION
## #️⃣연관된 이슈

> - close #87 

## 📝작업 내용

> 스페이스 서버 포트 번호를 3000에서 8090으로 바꾸고 도커 파일은 3000에서 8090으로 바꾸지 않아서 실행이 안되는 문제가 있었습니다

혹시 이미 이미지를 빌드했다면 아래 명령어로 새로 빌드하여 실행해주세요
```
docker-compose -f config/docker-compose-space-server.yml build
docker-compose -f config/docker-compose-space-server.yml up -d
```

혹시 안된다면.. 
`docker-compose -f config/docker-compose-space-server.yml build --no-cache`
 로 캐시 없이 재빌드하면 됩니다

서버가 잘 실행되면 알려주세요..!!!

### 스크린샷 (선택)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
