### PR TITLE
[BE] Setting: 서버별 테스트 환경 docker-compose.yml 서버별 작성

### DIFF
--- a/config/docker-compose-chat-server.yml
+++ b/config/docker-compose-chat-server.yml
@@ -1,47 +1,138 @@
-version: "3.9"
+version: '3.8'
 
 services:
-  kafka:
-    image: bitnami/kafka:3.6.1-debian-11-r0
-    container_name: kafka-single-broker
-    restart: unless-stopped
-    ports:
-      - "9092:9092"
-      - "9094:9094"
-    environment:
-      # Kafka 노드 ID 및 클러스터 설정
-      - KAFKA_NODE_ID=0
-      - KAFKA_PROCESS_ROLES=broker,controller  # 브로커 + 컨트롤러 역할 수행
-      - KAFKA_KRAFT_CLUSTER_ID=hPThGFTUS4u1FxH9KPznxg==  # 클러스터 ID (Base64 인코딩된 UUID)
-
-      # KRaft 모드 필수 환경 변수 추가
-      - KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=0@kafka-single-broker:9093  # 컨트롤러 노드 정보
-      - KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER  # 컨트롤러 리스너 설정
-
-      # 리스너 및 보안 설정
-      - KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT
-      - KAFKA_LISTENERS=INTERNAL://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093,EXTERNAL://0.0.0.0:9094
-      - KAFKA_ADVERTISED_LISTENERS=INTERNAL://kafka-single-broker:9092,EXTERNAL://localhost:9094
-      - KAFKA_INTER_BROKER_LISTENER_NAME=INTERNAL
-    networks:
-      - chat-network
-
   chat-server:
-    image: openjdk:21-jdk
+    image: imjanghyeok/smiletogether-chat-server:latest  # Docker Hub에서 가져오기
     container_name: chat-server
-    restart: unless-stopped
+    restart: always
     ports:
       - "8081:8081"
-    environment:
-      - SPRING_KAFKA_BOOTSTRAP_SERVERS=kafka-single-broker:9092
-      - SPRING_DATASOURCE_URL=jdbc:h2:mem:testdb
     networks:
-      - chat-network
+      - chat_network
+
+  kafka-ui:
+    image: provectuslabs/kafka-ui:latest
+    container_name: kafka-ui
+    ports:
+      - "5001:5001"
+    environment:
+      - KAFKA_CLUSTERS_0_NAME=LocalKafka
+      - KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS=kafka_01:9092,kafka_02:9092,kafka_03:9092
+      - DYNAMIC_CONFIG_ENABLED=true
+    depends_on:
+      - kafka_01
+    networks:
+      - kafka-network
+
+    # ✅ 컨트롤러 1개 (테스트 환경)
+  kafka_00:
+    image: bitnami/kafka:3.7.0
+    container_name: kafka_00
+    restart: unless-stopped
+    ports:
+      - '9093:9093'
+      - '19000:19000'
+    environment:
+      - KAFKA_CFG_NODE_ID=0
+      - KAFKA_KRAFT_MODE=true
+      - KAFKA_CFG_PROCESS_ROLES=controller
+      - KAFKA_KRAFT_CLUSTER_ID=hPThGFTUS4u1FxH9KPznxg==
+      - KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=0@kafka_00:9093
+      - KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER
+      - KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT
+      - KAFKA_LISTENERS=CONTROLLER://0.0.0.0:9093
+      - KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=true
+    networks:
+      - kafka-network
     volumes:
-      - ../bin:/app/bin
-    working_dir: /app
-    command: ["java", "-jar", "/app/bin/chat-server-0.0.1-SNAPSHOT.jar"]
+      - kafka_00:/bitnami/kafka
+
+  # ✅ 브로커 3개 (KRaft 모드 적용)
+  kafka_01:
+    image: bitnami/kafka:3.7.0
+    container_name: kafka_01
+    restart: unless-stopped
+    ports:
+      - '9094:9092'
+      - '19001:19001'
+    environment:
+      - KAFKA_CFG_NODE_ID=1
+      - KAFKA_KRAFT_MODE=true
+      - KAFKA_CFG_PROCESS_ROLES=broker
+      - KAFKA_KRAFT_CLUSTER_ID=hPThGFTUS4u1FxH9KPznxg==
+      - KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=0@kafka_00:9093
+      - KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER
+      - KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT
+      - KAFKA_LISTENERS=INTERNAL://0.0.0.0:9092,EXTERNAL://kafka_01:19001
+      - KAFKA_ADVERTISED_LISTENERS=INTERNAL://kafka_01:9092,EXTERNAL://host.docker.internal:19001
+      - KAFKA_INTER_BROKER_LISTENER_NAME=INTERNAL
+      - KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=true
+    networks:
+      - kafka-network
+    volumes:
+      - kafka_01:/bitnami/kafka
+
+  kafka_02:
+    image: bitnami/kafka:3.7.0
+    container_name: kafka_02
+    restart: unless-stopped
+    ports:
+      - '9095:9092'
+      - '19002:19002'
+    environment:
+      - KAFKA_CFG_NODE_ID=2
+      - KAFKA_KRAFT_MODE=true
+      - KAFKA_CFG_PROCESS_ROLES=broker
+      - KAFKA_KRAFT_CLUSTER_ID=hPThGFTUS4u1FxH9KPznxg==
+      - KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=0@kafka_00:9093
+      - KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER
+      - KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT
+      - KAFKA_LISTENERS=INTERNAL://0.0.0.0:9092,EXTERNAL://kafka_02:19002
+      - KAFKA_ADVERTISED_LISTENERS=INTERNAL://kafka_02:9092,EXTERNAL://host.docker.internal:19002
+      - KAFKA_INTER_BROKER_LISTENER_NAME=INTERNAL
+      - KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=true
+    networks:
+      - kafka-network
+    volumes:
+      - kafka_02:/bitnami/kafka
+
+  kafka_03:
+    image: bitnami/kafka:3.7.0
+    container_name: kafka_03
+    restart: unless-stopped
+    ports:
+      - '9096:9092'
+      - '19003:19003'
+    environment:
+      - KAFKA_CFG_NODE_ID=3
+      - KAFKA_KRAFT_MODE=true
+      - KAFKA_CFG_PROCESS_ROLES=broker
+      - KAFKA_KRAFT_CLUSTER_ID=hPThGFTUS4u1FxH9KPznxg==
+      - KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=0@kafka_00:9093
+      - KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER
+      - KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT
+      - KAFKA_LISTENERS=INTERNAL://0.0.0.0:9092,EXTERNAL://kafka_03:19003
+      - KAFKA_ADVERTISED_LISTENERS=INTERNAL://kafka_03:9092,EXTERNAL://host.docker.internal:19003
+      - KAFKA_INTER_BROKER_LISTENER_NAME=INTERNAL
+      - KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=true
+    networks:
+      - kafka-network
+    volumes:
+      - kafka_03:/bitnami/kafka
+
 
 networks:
-  chat-network:
+  chat_network:
     driver: bridge
+  kafka-network:
+    driver: bridge
+
+volumes:
+  kafka_00:
+    driver: local
+  kafka_01:
+    driver: local
+  kafka_02:
+    driver: local
+  kafka_03:
+    driver: local

--- a/config/docker-compose-chatting.yml
+++ b/config/docker-compose-chatting.yml
@@ -43,15 +43,14 @@ services:
     networks:
       - history_network
 
-# 히스토리 서버만 테스트시 주석 필요
-#  chat-server:
-#    image: imjanghyeok/smiletogether-chat-server:latest  # Docker Hub에서 가져오기
-#    container_name: chat-server
-#    restart: always
-#    ports:
-#      - "8081:8081"
-#    networks:
-#      - chat_network
+  chat-server:
+    image: imjanghyeok/smiletogether-chat-server:latest  # Docker Hub에서 가져오기
+    container_name: chat-server
+    restart: always
+    ports:
+      - "8081:8081"
+    networks:
+      - chat_network
 
   kafka-ui:
     image: provectuslabs/kafka-ui:latest
@@ -167,9 +166,8 @@ services:
 networks:
   history_network:
     driver: bridge
-  # 히스토리 서버만 테스트시 주석 필요
-  #  chat_network:
-#    driver: bridge
+  chat_network:
+    driver: bridge
   kafka-network:
     driver: bridge
 

--- a/config/docker-compose-history-server.yml
+++ b/config/docker-compose-history-server.yml
@@ -1,0 +1,172 @@
+version: '3.8'
+
+services:
+  mongodb:
+    image: mongo:latest
+    container_name: mongodb
+    restart: always
+    ports:
+      - 27017:27017
+    volumes:
+      - data:/data/db
+    environment:
+      - MONGO_INITDB_ROOT_USERNAME=rootuser
+      - MONGO_INITDB_ROOT_PASSWORD=rootpass
+    networks:
+      - history_network
+
+  mongo-express:
+    image: mongo-express:latest
+    container_name: mongo-express
+    restart: always
+    ports:
+      - 20000:8081  # 프론트에서 사용 가능하도록 포트 수정
+    environment:
+      - ME_CONFIG_MONGODB_ADMINUSERNAME=rootuser
+      - ME_CONFIG_MONGODB_ADMINPASSWORD=rootpass
+      - ME_CONFIG_MONGODB_SERVER=mongodb
+    depends_on:
+      - mongodb
+    networks:
+      - history_network
+
+  history-server:
+    image: imjanghyeok/smiletogether-history-server:latest  # Docker Hub에서 가져오기
+    container_name: history-server
+    restart: always
+    ports:
+      - "8083:8083"
+    environment:
+      - SPRING_DATA_MONGODB_URI=mongodb://rootuser:rootpass@mongodb:27017/history-db?authSource=admin
+    depends_on:
+      - mongodb
+    networks:
+      - history_network
+
+  kafka-ui:
+    image: provectuslabs/kafka-ui:latest
+    container_name: kafka-ui
+    ports:
+      - "5001:5001"
+    environment:
+      - KAFKA_CLUSTERS_0_NAME=LocalKafka
+      - KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS=kafka_01:9092,kafka_02:9092,kafka_03:9092
+      - DYNAMIC_CONFIG_ENABLED=true
+    depends_on:
+      - kafka_01
+    networks:
+      - kafka-network
+
+    # ✅ 컨트롤러 1개 (테스트 환경)
+  kafka_00:
+    image: bitnami/kafka:3.7.0
+    container_name: kafka_00
+    restart: unless-stopped
+    ports:
+      - '9093:9093'
+      - '19000:19000'
+    environment:
+      - KAFKA_CFG_NODE_ID=0
+      - KAFKA_KRAFT_MODE=true
+      - KAFKA_CFG_PROCESS_ROLES=controller
+      - KAFKA_KRAFT_CLUSTER_ID=hPThGFTUS4u1FxH9KPznxg==
+      - KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=0@kafka_00:9093
+      - KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER
+      - KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT
+      - KAFKA_LISTENERS=CONTROLLER://0.0.0.0:9093
+      - KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=true
+    networks:
+      - kafka-network
+    volumes:
+      - kafka_00:/bitnami/kafka
+
+  # ✅ 브로커 3개 (KRaft 모드 적용)
+  kafka_01:
+    image: bitnami/kafka:3.7.0
+    container_name: kafka_01
+    restart: unless-stopped
+    ports:
+      - '9094:9092'
+      - '19001:19001'
+    environment:
+      - KAFKA_CFG_NODE_ID=1
+      - KAFKA_KRAFT_MODE=true
+      - KAFKA_CFG_PROCESS_ROLES=broker
+      - KAFKA_KRAFT_CLUSTER_ID=hPThGFTUS4u1FxH9KPznxg==
+      - KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=0@kafka_00:9093
+      - KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER
+      - KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT
+      - KAFKA_LISTENERS=INTERNAL://0.0.0.0:9092,EXTERNAL://kafka_01:19001
+      - KAFKA_ADVERTISED_LISTENERS=INTERNAL://kafka_01:9092,EXTERNAL://host.docker.internal:19001
+      - KAFKA_INTER_BROKER_LISTENER_NAME=INTERNAL
+      - KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=true
+    networks:
+      - kafka-network
+    volumes:
+      - kafka_01:/bitnami/kafka
+
+  kafka_02:
+    image: bitnami/kafka:3.7.0
+    container_name: kafka_02
+    restart: unless-stopped
+    ports:
+      - '9095:9092'
+      - '19002:19002'
+    environment:
+      - KAFKA_CFG_NODE_ID=2
+      - KAFKA_KRAFT_MODE=true
+      - KAFKA_CFG_PROCESS_ROLES=broker
+      - KAFKA_KRAFT_CLUSTER_ID=hPThGFTUS4u1FxH9KPznxg==
+      - KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=0@kafka_00:9093
+      - KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER
+      - KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT
+      - KAFKA_LISTENERS=INTERNAL://0.0.0.0:9092,EXTERNAL://kafka_02:19002
+      - KAFKA_ADVERTISED_LISTENERS=INTERNAL://kafka_02:9092,EXTERNAL://host.docker.internal:19002
+      - KAFKA_INTER_BROKER_LISTENER_NAME=INTERNAL
+      - KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=true
+    networks:
+      - kafka-network
+    volumes:
+      - kafka_02:/bitnami/kafka
+
+  kafka_03:
+    image: bitnami/kafka:3.7.0
+    container_name: kafka_03
+    restart: unless-stopped
+    ports:
+      - '9096:9092'
+      - '19003:19003'
+    environment:
+      - KAFKA_CFG_NODE_ID=3
+      - KAFKA_KRAFT_MODE=true
+      - KAFKA_CFG_PROCESS_ROLES=broker
+      - KAFKA_KRAFT_CLUSTER_ID=hPThGFTUS4u1FxH9KPznxg==
+      - KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=0@kafka_00:9093
+      - KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER
+      - KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT
+      - KAFKA_LISTENERS=INTERNAL://0.0.0.0:9092,EXTERNAL://kafka_03:19003
+      - KAFKA_ADVERTISED_LISTENERS=INTERNAL://kafka_03:9092,EXTERNAL://host.docker.internal:19003
+      - KAFKA_INTER_BROKER_LISTENER_NAME=INTERNAL
+      - KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=true
+    networks:
+      - kafka-network
+    volumes:
+      - kafka_03:/bitnami/kafka
+
+
+networks:
+  history_network:
+    driver: bridge
+  kafka-network:
+    driver: bridge
+
+volumes:
+  data:
+  kafka_00:
+    driver: local
+  kafka_01:
+    driver: local
+  kafka_02:
+    driver: local
+  kafka_03:
+    driver: local


### PR DESCRIPTION
## #️⃣연관된 이슈

#126 

## 📝작업 내용

- [x] 히스토리 서버, 채팅 서버, 각각 테스트 환경에 대한 yml 작성
- [x] 통합 서버 테스트 환경에 대한 yml 작성

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
- docker-compose-chat-server.yml -> 채팅 서버만 테스트
- docker-compose-history-server.yml -> 히스토리 서버만 테스트
- docker-compose-chatting.yml -> 채팅 서버 및 히스토리 서버가 연동된 환경 테스트
