### PR TITLE
[BE] feat: 초대 링크 api 구현

### DIFF
--- a/backend/space-server/package.json
+++ b/backend/space-server/package.json
@@ -20,13 +20,16 @@
     "test:e2e": "jest --config ./test/jest-e2e.json"
   },
   "dependencies": {
+    "@liaoliaots/nestjs-redis": "^10.0.0",
     "@nestjs/common": "^10.0.0",
     "@nestjs/config": "^4.0.0",
     "@nestjs/core": "^10.0.0",
     "@nestjs/jwt": "^11.0.0",
+    "@nestjs/mapped-types": "*",
     "@nestjs/platform-express": "^10.0.0",
     "@prisma/client": "^6.3.1",
     "class-validator": "^0.14.1",
+    "ioredis": "^5.5.0",
     "reflect-metadata": "^0.2.0",
     "rxjs": "^7.8.1"
   },

--- a/backend/space-server/package.json
+++ b/backend/space-server/package.json
@@ -31,7 +31,8 @@
     "class-validator": "^0.14.1",
     "ioredis": "^5.5.0",
     "reflect-metadata": "^0.2.0",
-    "rxjs": "^7.8.1"
+    "rxjs": "^7.8.1",
+    "uuid": "^11.1.0"
   },
   "devDependencies": {
     "@nestjs/cli": "^10.0.0",

--- a/backend/space-server/pnpm-lock.yaml
+++ b/backend/space-server/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@liaoliaots/nestjs-redis':
+        specifier: ^10.0.0
+        version: 10.0.0(@nestjs/common@10.4.15(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.15)(ioredis@5.5.0)
       '@nestjs/common':
         specifier: ^10.0.0
         version: 10.4.15(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)
@@ -20,6 +23,9 @@ importers:
       '@nestjs/jwt':
         specifier: ^11.0.0
         version: 11.0.0(@nestjs/common@10.4.15(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))
+      '@nestjs/mapped-types':
+        specifier: '*'
+        version: 2.1.0(@nestjs/common@10.4.15(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(class-validator@0.14.1)(reflect-metadata@0.2.2)
       '@nestjs/platform-express':
         specifier: ^10.0.0
         version: 10.4.15(@nestjs/common@10.4.15(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.15)
@@ -29,6 +35,9 @@ importers:
       class-validator:
         specifier: ^0.14.1
         version: 0.14.1
+      ioredis:
+        specifier: ^5.5.0
+        version: 5.5.0
       reflect-metadata:
         specifier: ^0.2.0
         version: 0.2.2
@@ -327,6 +336,9 @@ packages:
     resolution: {integrity: sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==}
     deprecated: Use @eslint/object-schema instead
 
+  '@ioredis/commands@1.2.0':
+    resolution: {integrity: sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg==}
+
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
@@ -429,6 +441,14 @@ packages:
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
+  '@liaoliaots/nestjs-redis@10.0.0':
+    resolution: {integrity: sha512-uCTmlzM4q+UYADwsJEQph0mbf4u0MrktFhByi50M5fNy/+fJoWlhSqrgvjtVKjHnqydxy1gyuU6vHJEOBp9cjg==}
+    engines: {node: '>=16.13.0'}
+    peerDependencies:
+      '@nestjs/common': ^10.0.0
+      '@nestjs/core': ^10.0.0
+      ioredis: ^5.0.0
+
   '@ljharb/through@2.3.13':
     resolution: {integrity: sha512-/gKJun8NNiWGZJkGzI/Ragc53cOdcLNdzjLaIa+GEjguQs0ulsurx8WN0jijdK9yPqDvziX995sMRLyLt1uZMQ==}
     engines: {node: '>= 0.4'}
@@ -490,6 +510,19 @@ packages:
     resolution: {integrity: sha512-v7YRsW3Xi8HNTsO+jeHSEEqelX37TVWgwt+BcxtkG/OfXJEOs6GZdbdza200d6KqId1pJQZ6UPj1F0M6E+mxaA==}
     peerDependencies:
       '@nestjs/common': ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0
+
+  '@nestjs/mapped-types@2.1.0':
+    resolution: {integrity: sha512-W+n+rM69XsFdwORF11UqJahn4J3xi4g/ZEOlJNL6KoW5ygWSmBB2p0S2BZ4FQeS/NDH72e6xIcu35SfJnE8bXw==}
+    peerDependencies:
+      '@nestjs/common': ^10.0.0 || ^11.0.0
+      class-transformer: ^0.4.0 || ^0.5.0
+      class-validator: ^0.13.0 || ^0.14.0
+      reflect-metadata: ^0.1.12 || ^0.2.0
+    peerDependenciesMeta:
+      class-transformer:
+        optional: true
+      class-validator:
+        optional: true
 
   '@nestjs/platform-express@10.4.15':
     resolution: {integrity: sha512-63ZZPkXHjoDyO7ahGOVcybZCRa7/Scp6mObQKjcX/fTEq1YJeU75ELvMsuQgc8U2opMGOBD7GVuc4DV0oeDHoA==}
@@ -1061,6 +1094,10 @@ packages:
     resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
     engines: {node: '>=0.8'}
 
+  cluster-key-slot@1.1.2:
+    resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
+    engines: {node: '>=0.10.0'}
+
   co@4.6.0:
     resolution: {integrity: sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==}
     engines: {iojs: '>= 1.0.0', node: '>= 0.12.0'}
@@ -1194,6 +1231,10 @@ packages:
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
+
+  denque@2.1.0:
+    resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
+    engines: {node: '>=0.10'}
 
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
@@ -1649,6 +1690,10 @@ packages:
     resolution: {integrity: sha512-vI2w4zl/mDluHt9YEQ/543VTCwPKWiHzKtm9dM2V0NdFcqEexDAjUHzO1oA60HRNaVifGXXM1tRRNluLVHa0Kg==}
     engines: {node: '>=18'}
 
+  ioredis@5.5.0:
+    resolution: {integrity: sha512-7CutT89g23FfSa8MDoIFs2GYYa0PaNiW/OrT+nRyjRXHDZd17HmIgy+reOQ/yhh72NznNjGuS8kbCAcA4Ro4mw==}
+    engines: {node: '>=12.22.0'}
+
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
@@ -1963,8 +2008,14 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
+  lodash.defaults@4.2.0:
+    resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
+
   lodash.includes@4.3.0:
     resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
+
+  lodash.isarguments@3.1.0:
+    resolution: {integrity: sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==}
 
   lodash.isboolean@3.0.3:
     resolution: {integrity: sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==}
@@ -2346,6 +2397,14 @@ packages:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
 
+  redis-errors@1.2.0:
+    resolution: {integrity: sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==}
+    engines: {node: '>=4'}
+
+  redis-parser@3.0.0:
+    resolution: {integrity: sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==}
+    engines: {node: '>=4'}
+
   reflect-metadata@0.2.2:
     resolution: {integrity: sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==}
 
@@ -2511,6 +2570,9 @@ packages:
   stack-utils@2.0.6:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
     engines: {node: '>=10'}
+
+  standard-as-callback@2.1.0:
+    resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
 
   statuses@2.0.1:
     resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
@@ -2705,6 +2767,9 @@ packages:
   tsconfig-paths@4.2.0:
     resolution: {integrity: sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==}
     engines: {node: '>=6'}
+
+  tslib@2.7.0:
+    resolution: {integrity: sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -3145,6 +3210,8 @@ snapshots:
 
   '@humanwhocodes/object-schema@2.0.3': {}
 
+  '@ioredis/commands@1.2.0': {}
+
   '@isaacs/cliui@8.0.2':
     dependencies:
       string-width: 5.1.2
@@ -3353,6 +3420,13 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
 
+  '@liaoliaots/nestjs-redis@10.0.0(@nestjs/common@10.4.15(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.15)(ioredis@5.5.0)':
+    dependencies:
+      '@nestjs/common': 10.4.15(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)
+      '@nestjs/core': 10.4.15(@nestjs/common@10.4.15(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.15)(reflect-metadata@0.2.2)(rxjs@7.8.1)
+      ioredis: 5.5.0
+      tslib: 2.7.0
+
   '@ljharb/through@2.3.13':
     dependencies:
       call-bind: 1.0.8
@@ -3424,6 +3498,13 @@ snapshots:
       '@nestjs/common': 10.4.15(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)
       '@types/jsonwebtoken': 9.0.7
       jsonwebtoken: 9.0.2
+
+  '@nestjs/mapped-types@2.1.0(@nestjs/common@10.4.15(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(class-validator@0.14.1)(reflect-metadata@0.2.2)':
+    dependencies:
+      '@nestjs/common': 10.4.15(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)
+      reflect-metadata: 0.2.2
+    optionalDependencies:
+      class-validator: 0.14.1
 
   '@nestjs/platform-express@10.4.15(@nestjs/common@10.4.15(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.15)':
     dependencies:
@@ -4132,6 +4213,8 @@ snapshots:
 
   clone@1.0.4: {}
 
+  cluster-key-slot@1.1.2: {}
+
   co@4.6.0: {}
 
   collect-v8-coverage@1.0.2: {}
@@ -4249,6 +4332,8 @@ snapshots:
       gopd: 1.2.0
 
   delayed-stream@1.0.0: {}
+
+  denque@2.1.0: {}
 
   depd@2.0.0: {}
 
@@ -4779,6 +4864,20 @@ snapshots:
       strip-ansi: 6.0.1
       wrap-ansi: 6.2.0
 
+  ioredis@5.5.0:
+    dependencies:
+      '@ioredis/commands': 1.2.0
+      cluster-key-slot: 1.1.2
+      debug: 4.4.0
+      denque: 2.1.0
+      lodash.defaults: 4.2.0
+      lodash.isarguments: 3.1.0
+      redis-errors: 1.2.0
+      redis-parser: 3.0.0
+      standard-as-callback: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   ipaddr.js@1.9.1: {}
 
   is-arrayish@0.2.1: {}
@@ -5272,7 +5371,11 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
+  lodash.defaults@4.2.0: {}
+
   lodash.includes@4.3.0: {}
+
+  lodash.isarguments@3.1.0: {}
 
   lodash.isboolean@3.0.3: {}
 
@@ -5601,6 +5704,12 @@ snapshots:
     dependencies:
       picomatch: 2.3.1
 
+  redis-errors@1.2.0: {}
+
+  redis-parser@3.0.0:
+    dependencies:
+      redis-errors: 1.2.0
+
   reflect-metadata@0.2.2: {}
 
   repeat-string@1.6.1: {}
@@ -5774,6 +5883,8 @@ snapshots:
   stack-utils@2.0.6:
     dependencies:
       escape-string-regexp: 2.0.0
+
+  standard-as-callback@2.1.0: {}
 
   statuses@2.0.1: {}
 
@@ -5965,6 +6076,8 @@ snapshots:
       json5: 2.2.3
       minimist: 1.2.8
       strip-bom: 3.0.0
+
+  tslib@2.7.0: {}
 
   tslib@2.8.1: {}
 

--- a/backend/space-server/pnpm-lock.yaml
+++ b/backend/space-server/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       rxjs:
         specifier: ^7.8.1
         version: 7.8.1
+      uuid:
+        specifier: ^11.1.0
+        version: 11.1.0
     devDependencies:
       '@nestjs/cli':
         specifier: ^10.0.0
@@ -2837,6 +2840,10 @@ packages:
   utils-merge@1.0.1:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
+
+  uuid@11.1.0:
+    resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
+    hasBin: true
 
   v8-compile-cache-lib@3.0.1:
     resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
@@ -6125,6 +6132,8 @@ snapshots:
   util-deprecate@1.0.2: {}
 
   utils-merge@1.0.1: {}
+
+  uuid@11.1.0: {}
 
   v8-compile-cache-lib@3.0.1: {}
 

--- a/backend/space-server/src/app.module.ts
+++ b/backend/space-server/src/app.module.ts
@@ -4,9 +4,15 @@ import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { WorkspaceModule } from './workspace/workspace.module';
 import { ChannelModule } from './channel/channel.module';
+import { InviteModule } from './invite/invite.module';
 
 @Module({
-  imports: [ConfigModule.forRoot(), WorkspaceModule, ChannelModule],
+  imports: [
+    ConfigModule.forRoot(),
+    WorkspaceModule,
+    ChannelModule,
+    InviteModule,
+  ],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/backend/space-server/src/invite/invite.controller.ts
+++ b/backend/space-server/src/invite/invite.controller.ts
@@ -1,7 +1,18 @@
-import { Controller } from '@nestjs/common';
+import { Body, Controller, Post } from '@nestjs/common';
 import { InviteService } from './invite.service';
 
-@Controller('invite')
+@Controller('api/invite')
 export class InviteController {
   constructor(private readonly inviteService: InviteService) {}
+
+  @Post('generatelink')
+  async createInviteLink(
+    @Body() body: { domain: string; workspaceId: string },
+  ) {
+    const inviteLink = await this.inviteService.generateInviteLink(
+      body.domain,
+      body.workspaceId,
+    );
+    return { inviteLink };
+  }
 }

--- a/backend/space-server/src/invite/invite.controller.ts
+++ b/backend/space-server/src/invite/invite.controller.ts
@@ -1,0 +1,7 @@
+import { Controller } from '@nestjs/common';
+import { InviteService } from './invite.service';
+
+@Controller('invite')
+export class InviteController {
+  constructor(private readonly inviteService: InviteService) {}
+}

--- a/backend/space-server/src/invite/invite.controller.ts
+++ b/backend/space-server/src/invite/invite.controller.ts
@@ -15,4 +15,13 @@ export class InviteController {
     );
     return { inviteLink };
   }
+
+  @Post('acceptlink')
+  async acceptInvite(@Body() body: { userId: string; inviteUuid: string }) {
+    const result = await this.inviteService.acceptInviteLink(
+      body.inviteUuid,
+      body.userId,
+    );
+    return result;
+  }
 }

--- a/backend/space-server/src/invite/invite.controller.ts
+++ b/backend/space-server/src/invite/invite.controller.ts
@@ -8,13 +8,14 @@ export class InviteController {
   constructor(private readonly inviteService: InviteService) {}
 
   @UseGuards(AuthGuard)
-  @Post('link')
+  @Post('link/:workspaceId')
   async createInviteLink(
-    @Body() body: { domain: string; workspaceId: string },
+    @Param('workspaceId') workspaceId: string,
+    @Body('domain') domain: string,
   ) {
     const inviteLink = await this.inviteService.generateInviteLink(
-      body.domain,
-      body.workspaceId,
+      domain,
+      workspaceId,
     );
     return { inviteLink };
   }

--- a/backend/space-server/src/invite/invite.controller.ts
+++ b/backend/space-server/src/invite/invite.controller.ts
@@ -1,11 +1,14 @@
-import { Body, Controller, Post } from '@nestjs/common';
+import { Body, Controller, Param, Post, UseGuards } from '@nestjs/common';
 import { InviteService } from './invite.service';
+import { UserId } from 'src/decorators/user-id.decorator';
+import { AuthGuard } from 'src/guards/auth.guard';
 
 @Controller('api/invite')
 export class InviteController {
   constructor(private readonly inviteService: InviteService) {}
 
-  @Post('generatelink')
+  @UseGuards(AuthGuard)
+  @Post('link')
   async createInviteLink(
     @Body() body: { domain: string; workspaceId: string },
   ) {
@@ -16,11 +19,17 @@ export class InviteController {
     return { inviteLink };
   }
 
-  @Post('acceptlink')
-  async acceptInvite(@Body() body: { userId: string; inviteUuid: string }) {
+  @UseGuards(AuthGuard)
+  @Post('acceptlink/:inviteCode')
+  async acceptInvite(
+    @UserId() userId: string,
+    @Param('inviteCode') inviteCode: string,
+    @Body('userName') userName: string,
+  ) {
     const result = await this.inviteService.acceptInviteLink(
-      body.inviteUuid,
-      body.userId,
+      inviteCode,
+      userId,
+      userName,
     );
     return result;
   }

--- a/backend/space-server/src/invite/invite.module.ts
+++ b/backend/space-server/src/invite/invite.module.ts
@@ -2,9 +2,11 @@ import { Module } from '@nestjs/common';
 import { InviteService } from './invite.service';
 import { InviteController } from './invite.controller';
 import { RedisModule } from '@liaoliaots/nestjs-redis';
+import { PrismaModule } from 'prisma/prisma.module';
 
 @Module({
   imports: [
+    PrismaModule,
     RedisModule.forRoot({
       config: {
         host: 'localhost',

--- a/backend/space-server/src/invite/invite.module.ts
+++ b/backend/space-server/src/invite/invite.module.ts
@@ -3,10 +3,14 @@ import { InviteService } from './invite.service';
 import { InviteController } from './invite.controller';
 import { RedisModule } from '@liaoliaots/nestjs-redis';
 import { PrismaModule } from 'prisma/prisma.module';
+import { JwtModule } from '@nestjs/jwt';
 
 @Module({
   imports: [
     PrismaModule,
+    JwtModule.register({
+      signOptions: { expiresIn: '1h' },
+    }),
     RedisModule.forRoot({
       config: {
         host: 'localhost',

--- a/backend/space-server/src/invite/invite.module.ts
+++ b/backend/space-server/src/invite/invite.module.ts
@@ -1,0 +1,18 @@
+import { Module } from '@nestjs/common';
+import { InviteService } from './invite.service';
+import { InviteController } from './invite.controller';
+import { RedisModule } from '@liaoliaots/nestjs-redis';
+
+@Module({
+  imports: [
+    RedisModule.forRoot({
+      config: {
+        host: 'localhost',
+        port: 6381,
+      },
+    }),
+  ],
+  controllers: [InviteController],
+  providers: [InviteService],
+})
+export class InviteModule {}

--- a/backend/space-server/src/invite/invite.service.ts
+++ b/backend/space-server/src/invite/invite.service.ts
@@ -82,6 +82,23 @@ export class InviteService {
       },
     });
 
+    const defaultChannels = await this.prismaService.channel.findMany({
+      where: {
+        workspace_id: workspaceId,
+        is_private: false,
+      },
+    });
+
+    for (const defaultChannel of defaultChannels) {
+      await this.prismaService.channelUser.create({
+        data: {
+          channel_id: defaultChannel.channel_id,
+          user_id: userId,
+          channel_role: 'member',
+        },
+      });
+    }
+
     return { workspaceId };
   }
 }

--- a/backend/space-server/src/invite/invite.service.ts
+++ b/backend/space-server/src/invite/invite.service.ts
@@ -41,6 +41,7 @@ export class InviteService {
   async acceptInviteLink(
     inviteUuid: string,
     userId: string,
+    userName: string,
   ): Promise<{ workspaceId: string }> {
     const inviteKey = `invite_link:${inviteUuid}`;
 
@@ -74,14 +75,12 @@ export class InviteService {
         workspace_id: workspace.workspace_id,
         user_id: userId,
         role: 'member',
-        profile_name: `${userId}번 유저`,
+        profile_name: userName,
         profile_image: 'default.jpg',
         position: '',
         status_message: '',
       },
     });
-
-    await this.redis.del(inviteKey);
 
     return { workspaceId };
   }

--- a/backend/space-server/src/invite/invite.service.ts
+++ b/backend/space-server/src/invite/invite.service.ts
@@ -1,0 +1,12 @@
+import { RedisService } from '@liaoliaots/nestjs-redis';
+import { Injectable } from '@nestjs/common';
+import { Redis } from 'ioredis';
+
+@Injectable()
+export class InviteService {
+  private readonly redis: Redis | null;
+
+  constructor(private readonly redisService: RedisService) {
+    this.redis = this.redisService.getOrThrow();
+  }
+}

--- a/backend/space-server/src/invite/invite.service.ts
+++ b/backend/space-server/src/invite/invite.service.ts
@@ -1,6 +1,11 @@
 import { RedisService } from '@liaoliaots/nestjs-redis';
-import { Injectable } from '@nestjs/common';
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import { Redis } from 'ioredis';
+import { PrismaService } from 'prisma/prisma.service';
 import { v4 as uuidv4 } from 'uuid';
 
 @Injectable()
@@ -8,7 +13,10 @@ export class InviteService {
   private readonly redis: Redis | null;
   private readonly INVITE_CODE_EXPIRATION = 60 * 60; // 1시간
 
-  constructor(private readonly redisService: RedisService) {
+  constructor(
+    private readonly prismaService: PrismaService,
+    private readonly redisService: RedisService,
+  ) {
     this.redis = this.redisService.getOrThrow();
   }
 
@@ -28,5 +36,53 @@ export class InviteService {
     );
 
     return inviteUrl;
+  }
+
+  async acceptInviteLink(
+    inviteUuid: string,
+    userId: string,
+  ): Promise<{ workspaceId: string }> {
+    const inviteKey = `invite_link:${inviteUuid}`;
+
+    const workspaceId = await this.redis.get(inviteKey);
+    if (!workspaceId) {
+      throw new NotFoundException(
+        '초대 링크가 만료되었거나 존재하지 않습니다.',
+      );
+    }
+
+    const workspace = await this.prismaService.workspace.findUnique({
+      where: {
+        workspace_id: workspaceId,
+      },
+    });
+
+    if (!workspace) {
+      throw new NotFoundException('해당 워크스페이스가 존재하지 않습니다.');
+    }
+
+    const existingMember = await this.prismaService.workspaceUser.findFirst({
+      where: { workspace_id: workspaceId, user_id: userId },
+    });
+
+    if (existingMember) {
+      throw new BadRequestException('이미 워크스페이스에 참여 중입니다.');
+    }
+
+    await this.prismaService.workspaceUser.create({
+      data: {
+        workspace_id: workspace.workspace_id,
+        user_id: userId,
+        role: 'member',
+        profile_name: `${userId}번 유저`,
+        profile_image: 'default.jpg',
+        position: '',
+        status_message: '',
+      },
+    });
+
+    await this.redis.del(inviteKey);
+
+    return { workspaceId };
   }
 }

--- a/backend/space-server/src/invite/invite.service.ts
+++ b/backend/space-server/src/invite/invite.service.ts
@@ -1,12 +1,32 @@
 import { RedisService } from '@liaoliaots/nestjs-redis';
 import { Injectable } from '@nestjs/common';
 import { Redis } from 'ioredis';
+import { v4 as uuidv4 } from 'uuid';
 
 @Injectable()
 export class InviteService {
   private readonly redis: Redis | null;
+  private readonly INVITE_CODE_EXPIRATION = 60 * 60; // 1시간
 
   constructor(private readonly redisService: RedisService) {
     this.redis = this.redisService.getOrThrow();
+  }
+
+  async generateInviteLink(
+    domain: string,
+    workspaceId: string,
+  ): Promise<string> {
+    const inviteCode = uuidv4();
+    const inviteKey = `invite_link:${inviteCode}`;
+    const inviteUrl = `${domain}/invite/link/${inviteCode}`;
+
+    await this.redis.set(
+      inviteKey,
+      workspaceId,
+      'EX',
+      this.INVITE_CODE_EXPIRATION,
+    );
+
+    return inviteUrl;
   }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> - #125 

## 📝작업 내용

> 초대 링크 생성, 초대 링크로 초대 수락

로직은 아래와 같습니다.

### 초대 링크 생성 API

1. requestbody: 프론트엔드 도메인
2. 랜덤한 UUID를 생성하여 초대 링크의 키로 사용
    - redis에 저장되는 형태: { “invite_link:inviteCode” : “workspace_id” }
3. Redis에 저장하면서 만료 시간(예: 1시간)을 설정
4. http://도메인.com/invite/link/inviteCode 형태로 반환

### 링크 초대 수락 API

1. http://도메인.com/invite/link/inviteCode 페이지에서 초대 수락 API 호출
    -  로그인 안했을경우 로그인 페이지에서 로그인 진행 후 다시 초대 수락 페이지로 돌아와야함
    -  request body: { userName: 유저 닉네임 }
2. redis에서 workspace_id를 받아옴
    1. 워크스페이스 유저에 존재한다면 중복이므로 처리 x
    2. → 워크스페이스 유저 추가 **(유저 닉네임 정보 필요)**
    3. → workspcae_id 반환
        1. response body: { workspaceId: “아이디” }
3. response의 workspaceId를 이용해 해당 workspace 페이지로 라우팅


도메인과 workspaceId를 보내주시면 invitecode link를 반환해드립니다.
프론트에서 해당 링크로 접속 시, 초대 수락 api를 쏴주세요! 그러면 워크스페이스에 해당 유저가 추가됩니다.

이메일로 초대하는 기능은 위의 초대 링크 생성 로직에서 수정하여 이메일로 초대 링크 전송->그 링크 클릭 시 초대 수락, 워크스페이스 유저에 추가되는 형태로 구현하려 합니다.


### 스크린샷 (선택)
![generateInviteCode](https://github.com/user-attachments/assets/6ee003b0-ac2e-43fc-843e-ef4c2a6cd844)
![acceptinviteCode](https://github.com/user-attachments/assets/1bf3d023-339a-4581-b458-20552540be91)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

더 설명이 필요하거나 더 좋은 로직이 있다면 말해주세요!


