### PR TITLE
[BE] refactor: login, refresh response body 수정

### DIFF
--- a/backend/auth-server/src/auth/auth.controller.ts
+++ b/backend/auth-server/src/auth/auth.controller.ts
@@ -18,7 +18,12 @@ export class AuthController {
   async login(@Body('userId') userId: string, @Res() res: Response) {
     const { accessToken, refreshToken } = await this.authService.login(userId);
 
-    res.setHeader('Authorization', `Bearer ${accessToken}`);
+    res.cookie('accesstoken', accessToken, {
+      httpOnly: true,
+      secure: true,
+      sameSite: 'strict',
+      maxAge: 15 * 60 * 1000,
+    });
 
     res.cookie('refreshToken', refreshToken, {
       httpOnly: true,

--- a/backend/auth-server/src/auth/auth.controller.ts
+++ b/backend/auth-server/src/auth/auth.controller.ts
@@ -18,14 +18,6 @@ export class AuthController {
   async login(@Body('userId') userId: string, @Res() res: Response) {
     const { accessToken, refreshToken } = await this.authService.login(userId);
 
-    res.setHeader('Authorization', `Bearer ${accessToken}`);
-    res.cookie('accesstoken', accessToken, {
-      httpOnly: true,
-      secure: true,
-      sameSite: 'strict',
-      maxAge: 15 * 60 * 1000,
-    });
-
     res.cookie('refreshToken', refreshToken, {
       httpOnly: true,
       secure: true,
@@ -78,8 +70,10 @@ export class AuthController {
       userId: payload.userId,
     });
 
-    res.setHeader('Authorization', `Bearer ${newAccessToken}`);
-    return res.json({ message: 'issue AccessToken successful' });
+    return res.json({
+      message: 'issue AccessToken successful',
+      accessToken: newAccessToken,
+    });
   }
 
   @Get('verifyAccessToken')

--- a/backend/auth-server/src/auth/auth.controller.ts
+++ b/backend/auth-server/src/auth/auth.controller.ts
@@ -18,6 +18,7 @@ export class AuthController {
   async login(@Body('userId') userId: string, @Res() res: Response) {
     const { accessToken, refreshToken } = await this.authService.login(userId);
 
+    res.setHeader('Authorization', `Bearer ${accessToken}`);
     res.cookie('accesstoken', accessToken, {
       httpOnly: true,
       secure: true,
@@ -32,7 +33,7 @@ export class AuthController {
       maxAge: 7 * 24 * 60 * 60 * 1000,
     });
 
-    return res.json({ message: 'Login successful' });
+    return res.json({ message: 'Login successful', accessToken: accessToken });
   }
 
   @Post('logout')


### PR DESCRIPTION
## #️⃣연관된 이슈

> - #150 

## 📝작업 내용

> 작업한 내용을 작성해주세요.

원래 login 시 토큰 발급을 아래와 같은 형태로 header에 담아서 드렸는데
res.setHeader('Authorization', `Bearer ${accessToken}`);

헤더로 드리니까 accessToken을 추출해서 저장할 때 const authorization = response.config.headers.Authorization; 이렇게 깊게 들어가야하는데 헤더 타입이 string으로 고정되는게 아니라 string | number | true | AxiosHeaders | string[] 등으로 나뉠 수 있어서 또 String으로 감아야하더라구요

프론트에서 처리하기도 번거롭고 spring에서는 spring에서 헤더 추출하는 방법이 또 다르게 번거로울 것 같아 
{ message: 'Login successful', accessToken: accessToken }
이렇게 response body로 받을 수 있도록 수정했습니다.
api 명세서도 수정했습니다

헤더로 보내나 body로 보내나 받는 사람 입장에서는 큰 차이 없을거라 생각했는데 axios를 쓸 때나 spring을 쓸 때는 또 다르게 처리해야할 수도 있다는 생각을 못했네요.. 

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
