### PR TITLE
[FE] feat : 로그인 및 회원가입 연동

### DIFF
--- a/frontend/src/apis/user/index.ts
+++ b/frontend/src/apis/user/index.ts
@@ -1,25 +1,41 @@
 import https from '@/lib/https';
-import axios from 'axios';
 
 export const postLogin = async (email: string) => {
-  const response = await https.post(`http://localhost:8080/api/auth/sign-in`, {
-    email,
-  });
-  if (response.data.accessToken)
-    localStorage.setItem('access-token', response.data.accessToken);
+  const signInResponse = await https.post(
+    `http://localhost:8080/api/auth/sign-in`,
+    {
+      email,
+    }
+  );
 
-  return response;
+  const { isMember, member } = signInResponse.data;
+
+  if (!isMember) return signInResponse;
+
+  const issueTokenResponse = await https.post(
+    `http://localhost:8091/api/auth/login`,
+    {
+      userId: member.id,
+    }
+  );
+  if (issueTokenResponse.data.accessToken)
+    localStorage.setItem('access-token', issueTokenResponse.data.accessToken);
+
+  return issueTokenResponse;
 };
 
 export const postRegister = async (username: string, email: string) => {
-  const response = await https.post(`http://localhost:8080/api/auth/sign-up`, {
-    username,
-    email,
-  });
-  if (response.data.accessToken)
-    localStorage.setItem('access-token', response.data.accessToken);
-
-  return response;
+  const registerResponse = await https.post(
+    `http://localhost:8080/api/auth/sign-up`,
+    {
+      username,
+      email,
+    }
+  );
+  if (registerResponse.data.code == '201') {
+    return await postLogin(email);
+  }
+  return registerResponse;
 };
 
 export const postRefreshToken = async () => {

--- a/frontend/src/apis/user/index.ts
+++ b/frontend/src/apis/user/index.ts
@@ -1,12 +1,24 @@
 import https from '@/lib/https';
+import axios from 'axios';
 
 export const postLogin = async (email: string) => {
-  const response = await https.post(`http://localhost:8091/api/auth/sign-in`, {
+  const response = await https.post(`http://localhost:8080/api/auth/sign-in`, {
     email,
   });
   if (response.data.accessToken)
     localStorage.setItem('access-token', response.data.accessToken);
-  //else: 회원가입 페이지로 라우팅
+
+  return response;
+};
+
+export const postRegister = async (username: string, email: string) => {
+  const response = await https.post(`http://localhost:8080/api/auth/sign-up`, {
+    username,
+    email,
+  });
+  if (response.data.accessToken)
+    localStorage.setItem('access-token', response.data.accessToken);
+
   return response;
 };
 

--- a/frontend/src/apis/user/index.ts
+++ b/frontend/src/apis/user/index.ts
@@ -1,14 +1,33 @@
 import https from '@/lib/https';
 
-export const postLogin = async (userId: string) => {
-  const response = await https.post(`/api/auth/login`, {
-    userId,
+export const postLogin = async (email: string) => {
+  const response = await https.post(`http://localhost:8091/api/auth/sign-in`, {
+    email,
   });
-  localStorage.setItem('access-token', response.data.accessToken);
+  if (response.data.accessToken)
+    localStorage.setItem('access-token', response.data.accessToken);
+  //else: 회원가입 페이지로 라우팅
   return response;
 };
 
 export const postRefreshToken = async () => {
-  const response = await https.post('/api/auth/refresh');
+  const response = await https.post('http://localhost:8091/api/auth/refresh');
+  return response;
+};
+
+export const postSendEmailCode = async (email: string) => {
+  await https.post(`http://localhost:8080/api/auth/send-code?email=${email}`);
+  return;
+};
+
+export const postConfirmEmail = async (email: string, code: string) => {
+  const response = await https.post(
+    `http://localhost:8080/api/auth/certificate-email`,
+    {
+      email,
+      code,
+    }
+  );
+  console.log(response, response.data);
   return response;
 };

--- a/frontend/src/components/login/InputNicknameForm.tsx
+++ b/frontend/src/components/login/InputNicknameForm.tsx
@@ -1,0 +1,27 @@
+import { FormEvent } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+
+interface InputNicknameFormProps {
+  onSubmit: (e: FormEvent<HTMLFormElement>) => void;
+  placeholder: string;
+}
+
+export const InputNicknameForm = ({
+  onSubmit,
+  placeholder,
+}: InputNicknameFormProps) => {
+  return (
+    <form className="space-y-4" onSubmit={onSubmit}>
+      <Input
+        type="text"
+        name="name"
+        placeholder={placeholder}
+        className="w-full px-3 py-2 border rounded-md"
+      />
+      <Button className="w-full bg-amber-300 hover:bg-rose-200 text-white py-2 rounded-md">
+        계속
+      </Button>
+    </form>
+  );
+};

--- a/frontend/src/lib/https.ts
+++ b/frontend/src/lib/https.ts
@@ -15,11 +15,15 @@ https.interceptors.request.use(
     const isMockApi = mockApiList.some(item => config.url!.startsWith(item));
     if (isMockApi) {
       config.baseURL = '';
-    } else if (config.url!.startsWith('/api/auth')) {
-      config.baseURL = 'http://localhost:8091';
-    } else if (config.url!.startsWith('/api/member')) {
-      config.baseURL = 'http://localhost:8080';
-    } else config.baseURL = import.meta.env.VITE_BASE_SERVER_API_URL;
+    } else if (
+      config.url!.startsWith('/api/workspaces') ||
+      config.url!.startsWith('/api/invite') ||
+      config.url!.startsWith('/api/channels')
+    ) {
+      config.baseURL = import.meta.env.VITE_BASE_SERVER_API_URL;
+    } else {
+      config.baseURL = config.url;
+    }
     config.headers.Authorization = `Bearer ${getToken()}`;
     return config;
   },

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -17,7 +17,6 @@ export const isValidKoreanEnglish = (text: string): boolean => {
 };
 
 export const getToken = () => {
-  //return 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiI0YTdlYTQzZC1iZWI3LTRlN2ItOTk0YS05ZTlmNTYyMjA1MzIiLCJpYXQiOjE3NDEwOTYxMTYsImV4cCI6MTc0MTA5OTcxNn0.jhugfwnVay9-o0oIQCxkQRBT8jLuYBljMitgqeYw984';
   return localStorage.getItem('access-token');
 };
 

--- a/frontend/src/pages/login/ConfirmEmailPage.tsx
+++ b/frontend/src/pages/login/ConfirmEmailPage.tsx
@@ -28,7 +28,6 @@ const ConfirmEmailPage = () => {
 
     if (confirmResponse.data.code === '200') {
       const loginResponse = await postLogin(email);
-      console.log(loginResponse.data);
 
       if (loginResponse.data.isMember) {
         navigate('/workspaces');
@@ -46,7 +45,7 @@ const ConfirmEmailPage = () => {
     try {
       const registerResponse = await postRegister(name, email);
       console.log('회원가입 성공', registerResponse);
-      navigate('/workspace');
+      navigate('/workspaces');
     } catch (error) {
       console.error('회원가입 실패', error);
       alert('회원가입에 실패했습니다.');

--- a/frontend/src/pages/login/ConfirmEmailPage.tsx
+++ b/frontend/src/pages/login/ConfirmEmailPage.tsx
@@ -1,20 +1,39 @@
-import { postLogin } from '@/apis/user';
+import { postConfirmEmail, postLogin } from '@/apis/user';
 import { InputCodeForm } from '@/components/login/InputCodeForm';
 import { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router';
+import { useLocation, useNavigate } from 'react-router';
 
 const ConfirmEmailPage = () => {
-  const [code, setCode] = useState<string>('');
   const navigate = useNavigate();
+  const location = useLocation();
+  const [code, setCode] = useState<string>('');
+
+  const email = location.state?.email;
 
   const handleLogin = async () => {
-    const response = await postLogin('4a7ea43d-beb7-4e7b-994a-9e9f56220532');
+    if (email) {
+      const response = await postConfirmEmail(email, code);
+
+      if (response.data.code === '400') {
+        alert(response.data.message);
+        return;
+      }
+
+      if (response.data.code === '200') {
+        const response = await postLogin(email);
+        console.log(response.data);
+        return;
+      }
+    } else {
+      alert('이메일을 다시 전송해주세요.');
+      navigate('/');
+    }
   };
   useEffect(() => {
     if (code.length === 6) {
       try {
         handleLogin();
-        navigate('/workspaces');
+        //navigate('/workspaces');
       } catch (e) {
         alert('로그인 실패');
       }

--- a/frontend/src/pages/login/ConfirmEmailPage.tsx
+++ b/frontend/src/pages/login/ConfirmEmailPage.tsx
@@ -1,39 +1,62 @@
-import { postConfirmEmail, postLogin } from '@/apis/user';
+import { postConfirmEmail, postLogin, postRegister } from '@/apis/user';
 import { InputCodeForm } from '@/components/login/InputCodeForm';
-import { useEffect, useState } from 'react';
+import { InputNicknameForm } from '@/components/login/InputNicknameForm';
+import { FormEvent, useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router';
 
 const ConfirmEmailPage = () => {
   const navigate = useNavigate();
   const location = useLocation();
-  const [code, setCode] = useState<string>('');
+  const [code, setCode] = useState('');
+  const [isRegistering, setIsRegistering] = useState(false);
 
   const email = location.state?.email;
 
   const handleLogin = async () => {
-    if (email) {
-      const response = await postConfirmEmail(email, code);
-
-      if (response.data.code === '400') {
-        alert(response.data.message);
-        return;
-      }
-
-      if (response.data.code === '200') {
-        const response = await postLogin(email);
-        console.log(response.data);
-        return;
-      }
-    } else {
+    if (!email) {
       alert('이메일을 다시 전송해주세요.');
       navigate('/');
+      return;
+    }
+
+    const confirmResponse = await postConfirmEmail(email, code);
+
+    if (confirmResponse.data.code === '400') {
+      alert(confirmResponse.data.message);
+      return;
+    }
+
+    if (confirmResponse.data.code === '200') {
+      const loginResponse = await postLogin(email);
+      console.log(loginResponse.data);
+
+      if (loginResponse.data.isMember) {
+        navigate('/workspaces');
+      } else {
+        setIsRegistering(true);
+      }
     }
   };
+
+  const handleRegister = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const formData = new FormData(e.currentTarget);
+    const name = formData.get('name') as string;
+    console.log(name);
+    try {
+      const registerResponse = await postRegister(name, email);
+      console.log('회원가입 성공', registerResponse);
+      navigate('/workspace');
+    } catch (error) {
+      console.error('회원가입 실패', error);
+      alert('회원가입에 실패했습니다.');
+    }
+  };
+
   useEffect(() => {
     if (code.length === 6) {
       try {
         handleLogin();
-        //navigate('/workspaces');
       } catch (e) {
         alert('로그인 실패');
       }
@@ -44,17 +67,36 @@ const ConfirmEmailPage = () => {
     <div className="min-h-screen flex flex-col items-center justify-center bg-white p-4">
       <div className="text-2xl font-bold text-zinc-950 mb-8">smileTogether</div>
       <div className="w-full max-w-md space-y-6">
-        <div className="text-center space-y-2">
-          <h1 className="text-3xl font-bold text-zinc-950">
-            코드는 이메일에서 확인하세요
-          </h1>
-          <p className="text-sm text-zinc-500">
-            코드는 잠시 후에 만료되니 서둘러 입력하세요.
-          </p>
-        </div>
-        <div className="flex justify-center items-center">
-          <InputCodeForm code={code} setCode={setCode} />
-        </div>
+        {!isRegistering ? (
+          <>
+            <div className="text-center space-y-2">
+              <h1 className="text-3xl font-bold text-zinc-950">
+                코드는 이메일에서 확인하세요
+              </h1>
+              <p className="text-sm text-zinc-500">
+                코드는 잠시 후에 만료되니 서둘러 입력하세요.
+              </p>
+            </div>
+            <div className="flex justify-center items-center">
+              <InputCodeForm code={code} setCode={setCode} />
+            </div>
+          </>
+        ) : (
+          <>
+            <div className="text-center space-y-2">
+              <h1 className="text-3xl font-bold text-zinc-950">
+                닉네임을 입력해주세요
+              </h1>
+              <p className="text-sm text-zinc-500">
+                닉네임만 입력하면 회원가입이 끝나요!
+              </p>
+            </div>
+            <InputNicknameForm
+              onSubmit={handleRegister}
+              placeholder={email?.split('@')[0] || email}
+            />
+          </>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/pages/login/LoginPage.tsx
+++ b/frontend/src/pages/login/LoginPage.tsx
@@ -1,3 +1,4 @@
+import { postSendEmailCode } from '@/apis/user';
 import { LoginForm } from '@/components/login/LoginForm';
 import { FormEvent } from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -5,14 +6,19 @@ import { useNavigate } from 'react-router-dom';
 const LoginPage = () => {
   const navigate = useNavigate();
 
-  const handleEmailSubmit = (e: FormEvent<HTMLFormElement>) => {
+  const handleEmailSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     //이메일 전송
     const formData = new FormData(e.currentTarget);
     const email = formData.get('email') as string;
-    console.log(email);
-
-    navigate('/confirmemail');
+    try {
+      await postSendEmailCode(email);
+      console.log('이메일 전송 성공', email);
+      navigate('/confirmemail', { state: { email: email } });
+    } catch (error) {
+      console.error('이메일 전송 실패', error);
+      alert('이메일 전송에 실패했습니다.');
+    }
   };
 
   return (

--- a/frontend/src/pages/workspace/WorkspaceListPage.tsx
+++ b/frontend/src/pages/workspace/WorkspaceListPage.tsx
@@ -22,7 +22,7 @@ const WorkSpaceListPage = () => {
         <h1 className="text-4xl">smiletogether</h1>
         {workspacesInfo && workspacesInfo?.workspaces.length === 0 && (
           <div className="py-10 text-2xl">
-            가입되어 있는 워크스페이가 없습니다.
+            가입되어 있는 워크스페이스가 없습니다.
           </div>
         )}
         <Button


### PR DESCRIPTION
## #️⃣연관된 이슈

> - #160

## 📝작업 내용

> 작업한 내용을 작성해주세요.

이메일 인증
->로그인
->로그인 결과 isMember이 false면 회원가입창으로 이동, 닉네임 입력받음
->회원가입 후 다시 로그인, 토큰 발급받아 localStorage와 cookie에 저장

로그인 시 response body로 userId, userName, email이 오는데 프론트에서 어떻게 활용하는지 자세히 모르겠어서는 따로 상태관리로 저장해두진 않았어요 userStore 등에서 필요하면 저장해서 쓰시면 될 것 같아요

멤버서버 도커 실행시키고 작업해주세요


### 스크린샷 (선택)

![image](https://github.com/user-attachments/assets/1ea64077-19ba-4ae8-9922-faa4497913c4)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

그리고 api/auth/sign-in에서 발급된 jwt에 userId가 없길래 로그인 후에 기존 토큰발급(로그인) api api/auth/login에서 토큰 새로 발급해서 넣었습니다..

그리고 member 서버 volume이 없어서 일부러 저장되고 곧 만료되게 해두신건가요??
그리고 가끔 이메일 인증코드 전송이 안되는 문제가 있는데 서버 껐다 키면 되더라구요

