### PR TITLE
[BE] feat: 워크스페이스 생성/채널 생성 시 userId 대신 email 추가

### DIFF
--- a/backend/space-server/src/channel/channel.service.ts
+++ b/backend/space-server/src/channel/channel.service.ts
@@ -32,6 +32,20 @@ export class ChannelService {
     }
   };
 
+  getUserIdByEmail = async (email: string): Promise<string> => {
+    try {
+      const response = await fetch(
+        `http://localhost:8080/api/auth/check-memberId?email=${encodeURIComponent(email)}`,
+      );
+      if (!response.ok) return '해당 email의 userId가 존재하지 않습니다.';
+      const data = await response.json();
+      return data.userId || '해당 email의 userId가 존재하지 않습니다.';
+    } catch (error) {
+      console.error(error);
+      return '해당 email의 userId가 존재하지 않습니다.';
+    }
+  };
+
   async createChannel(
     userId: string,
     createChannelDto: CreateChannelDto,
@@ -69,7 +83,7 @@ export class ChannelService {
     });
 
     for (const email of emails) {
-      const newUserId = await this.getEmailByUserId(email);
+      const newUserId = await this.getUserIdByEmail(email);
       if (isUUID(newUserId))
         await this.joinChannel(newUserId, newChannel.channel_id);
       else

--- a/backend/space-server/src/channel/dto/create-channel.dto.ts
+++ b/backend/space-server/src/channel/dto/create-channel.dto.ts
@@ -9,9 +9,7 @@ export class CreateChannelDto {
   @IsNotEmpty()
   name: string;
 
-  @IsString()
-  @IsNotEmpty()
-  description: string;
+  emails: string[];
 
   @IsNotEmpty()
   isPrivate: boolean;

--- a/backend/space-server/src/workspace/dto/create-workspace.dto.ts
+++ b/backend/space-server/src/workspace/dto/create-workspace.dto.ts
@@ -1,4 +1,4 @@
-import { IsString, IsOptional, IsArray, IsNotEmpty } from 'class-validator';
+import { IsString, IsOptional, IsNotEmpty } from 'class-validator';
 
 export class CreateWorkspaceDto {
   @IsString()
@@ -16,7 +16,5 @@ export class CreateWorkspaceDto {
   @IsOptional()
   profileImage?: string;
 
-  @IsArray()
-  @IsString()
-  inviteUserList: string[];
+  inviteEmailList: string[];
 }

--- a/backend/space-server/src/workspace/workspace.service.ts
+++ b/backend/space-server/src/workspace/workspace.service.ts
@@ -13,6 +13,7 @@ import { WorkspaceDetailResponseDto } from './dto/workspace-detail.dto';
 import { WorkspaceDeleteResponseDto } from './dto/delete-workspace.dto';
 import { InviteWorkspaceDto } from './dto/invite-workspace.dto';
 import { ProfileResponseDto } from 'src/common/dto/profile-response.dto';
+import { isUUID } from 'class-validator';
 
 @Injectable()
 export class WorkspaceService {
@@ -33,6 +34,20 @@ export class WorkspaceService {
     } catch (error) {
       console.error(error);
       return '해당 userId의 email이 존재하지 않습니다.';
+    }
+  };
+
+  getNameByUserId = async (userId: string): Promise<string> => {
+    try {
+      const response = await fetch(
+        `http://localhost:8080/api/auth/identify-user-name?userId=${userId}`,
+      );
+      if (!response.ok) return '해당 userId의 userName이 존재하지 않습니다.';
+      const data = await response.json();
+      return data.userName || '해당 userId의 userName이 존재하지 않습니다.';
+    } catch (error) {
+      console.error(error);
+      return '해당 userId의 userName이 존재하지 않습니다.';
     }
   };
 
@@ -83,7 +98,7 @@ export class WorkspaceService {
   async createWorkspace(
     createWorkspaceDto: CreateWorkspaceDto,
   ): Promise<WorkspaceResponseDto> {
-    const { workspaceName, ownerId, userName, profileImage, inviteUserList } =
+    const { workspaceName, ownerId, userName, profileImage, inviteEmailList } =
       createWorkspaceDto;
 
     const inviteResults = {
@@ -133,34 +148,42 @@ export class WorkspaceService {
       });
 
       // 초대된 사용자들 처리
-      for (const userId of inviteUserList) {
-        try {
-          // 워크스페이스 멤버로 추가
-          await prisma.workspaceUser.create({
-            data: {
-              workspace_id: workspace.workspace_id,
-              user_id: userId,
-              role: 'member',
-              profile_name: `${userId}번 유저`, // 추후 사용자 DB에서 이름 가져오기
-              profile_image: 'default.jpg',
-              position: '',
-              status_message: '',
-            },
-          });
+      for (const email of inviteEmailList) {
+        const newUserId = await this.getEmailByUserId(email);
+        const newUserNickName = await this.getNameByUserId(newUserId);
+        if (isUUID(newUserId)) {
+          try {
+            // 워크스페이스 멤버로 추가
+            await prisma.workspaceUser.create({
+              data: {
+                workspace_id: workspace.workspace_id,
+                user_id: newUserId,
+                role: 'member',
+                profile_name: newUserNickName,
+                profile_image: 'default.jpg',
+                position: '',
+                status_message: '',
+              },
+            });
 
-          // 기본 채널에 추가
-          await prisma.channelUser.create({
-            data: {
-              channel_id: defaultChannel.channel_id,
-              user_id: userId,
-              channel_role: 'member',
-            },
-          });
+            // 기본 채널에 추가
+            await prisma.channelUser.create({
+              data: {
+                channel_id: defaultChannel.channel_id,
+                user_id: newUserId,
+                channel_role: 'member',
+              },
+            });
 
-          inviteResults.success.push(userId);
-        } catch (error) {
-          this.logger.error(`Failed to invite user ${userId}:`, error);
-          inviteResults.failed.push(userId);
+            inviteResults.success.push(email);
+          } catch (error) {
+            console.log(`Failed to invite user ${email}:`, error);
+            inviteResults.failed.push(email);
+          }
+        } else {
+          //이메일에 초대링크 전송
+          console.log('해당 email로 조회된 userId가 없습니다.');
+          inviteResults.failed.push(email);
         }
       }
 

--- a/backend/space-server/src/workspace/workspace.service.ts
+++ b/backend/space-server/src/workspace/workspace.service.ts
@@ -37,6 +37,20 @@ export class WorkspaceService {
     }
   };
 
+  getUserIdByEmail = async (email: string): Promise<string> => {
+    try {
+      const response = await fetch(
+        `http://localhost:8080/api/auth/check-memberId?email=${encodeURIComponent(email)}`,
+      );
+      if (!response.ok) return '해당 email의 userId가 존재하지 않습니다.';
+      const data = await response.json();
+      return data.userId || '해당 email의 userId가 존재하지 않습니다.';
+    } catch (error) {
+      console.error(error);
+      return '해당 email의 userId가 존재하지 않습니다.';
+    }
+  };
+
   getNameByUserId = async (userId: string): Promise<string> => {
     try {
       const response = await fetch(
@@ -149,8 +163,10 @@ export class WorkspaceService {
 
       // 초대된 사용자들 처리
       for (const email of inviteEmailList) {
-        const newUserId = await this.getEmailByUserId(email);
+        console.log('초대할 email: ', email);
+        const newUserId = await this.getUserIdByEmail(email);
         const newUserNickName = await this.getNameByUserId(newUserId);
+        console.log(newUserId, newUserNickName);
         if (isUUID(newUserId)) {
           try {
             // 워크스페이스 멤버로 추가
@@ -181,8 +197,13 @@ export class WorkspaceService {
             inviteResults.failed.push(email);
           }
         } else {
-          //이메일에 초대링크 전송
-          console.log('해당 email로 조회된 userId가 없습니다.');
+          console.log(
+            '해당 이메일로 조회된 userId가 올바르지 않습니다.',
+            '조회 한 userEmail: ',
+            email,
+            '조회 된 userId: ',
+            newUserId,
+          );
           inviteResults.failed.push(email);
         }
       }


### PR DESCRIPTION
## #️⃣연관된 이슈

> - #171

## 📝작업 내용

> 작업한 내용을 작성해주세요.

워크스페이스 생성/채널 생성 기존은 userId 넣어야했던거 email로 넣어도 되도록 수정했습니다
본래대로라면 워크스페이스 생성과정에서 유저 초대할 때 이메일 전송까지 해야하는데, 그러기엔 연동테스트시에 시간이 부족할 것 같아 member 서버에 있는 유저만 초대되게 했습니다. 

직접 회원가입하거나 더미 데이터에 있는 email을 넣으면 유저 추가가 가능합니다.
member서버에 존재하는 더미 데이터는 아래와 같습니다

id	username	email
550e8400-e29b-41d4-a716-446655440000	test1	test1@example.com
550e8400-e29b-41d4-a716-446655440001	test2	test2@example.com
550e8400-e29b-41d4-a716-446655440002	test3	test3@example.com
550e8400-e29b-41d4-a716-446655440003	test4	test4@example.com
550e8400-e29b-41d4-a716-446655440004	test5	test5@example.com
550e8400-e29b-41d4-a716-446655440005	test6	test6@example.com
550e8400-e29b-41d4-a716-446655440006	test7	test7@example.com
550e8400-e29b-41d4-a716-446655440007	test8	test8@example.com
550e8400-e29b-41d4-a716-446655440008	test9	test9@example.com
550e8400-e29b-41d4-a716-446655440009	test10	test10@example.com
550e8400-e29b-41d4-a716-44665544000A	test11	test11@example.com
550e8400-e29b-41d4-a716-44665544000B	test12	test12@example.com
550e8400-e29b-41d4-a716-44665544000C	test13	test13@example.com
550e8400-e29b-41d4-a716-44665544000D	test14	test14@example.com
550e8400-e29b-41d4-a716-44665544000E	test15	test15@example.com


워크스페이스 생성/채널 생성 명세서 업데이트했으니 확인부탁드립니다!



### 스크린샷 (선택)




## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
