### PR TITLE
[FE] fix : 채널 바꿔도 초기 메세지 남는 오류 수정

### DIFF
--- a/frontend/src/pages/channel/ChannelPage.tsx
+++ b/frontend/src/pages/channel/ChannelPage.tsx
@@ -13,7 +13,6 @@ const ChannelPage = () => {
   const { workspaceId, channelId } = useParams();
   const { channelData, isChannelLoading, isChannelError } =
     useGetChannel(channelId);
-  console.log(channelData?.channelName, channelData, channelData?.createdBy);
   const { client, messages: initailMessages } = useWebSocket({
     workspaceId,
     channelId,
@@ -41,6 +40,11 @@ const ChannelPage = () => {
   useEffect(() => {
     setMessages(initailMessages);
   }, [initailMessages]);
+
+  // 채널 ID가 변경될 때마다 메시지를 초기화
+  useEffect(() => {
+    setMessages([]); // 채널이 바뀔 때 메시지를 초기화
+  }, [channelId]);
 
   // 메시지가 변경될 때마다 항상 스크롤 하단으로 이동
   useEffect(() => {


### PR DESCRIPTION
## #️⃣연관된 이슈

> - #185 

## 📝작업 내용

> 작업한 내용을 작성해주세요.

잠깐 확인해보니까 채널을 바꿔도 initialMessage를 초기화하는 로직이 없더라구요 그래서 채널을 바꿔도 메세지가 그대로 남은 것 같아서 채널 바꾸면 initailMessage 초기화하는 로직 추가했습니다

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
