### PR TITLE
[FE] refactor: 로그인 기능 API 및 비즈니스 로직 분리를 통한 코드 구조화

### DIFF
--- a/config/docker-compose-member-server.yml
+++ b/config/docker-compose-member-server.yml
@@ -1,8 +1,8 @@
-version: "3"
+version: '3'
 services:
-  member-server:
-    image: imjanghyeok/smiletogether-member-server:latest
-    restart: always
-    ports:
-      - 8080:8080
-    container_name: member-member-server
+    member-server:
+        image: imjanghyeok/smiletogether-member-server:latest
+        restart: always
+        ports:
+            - 8080:8080
+        container_name: member-member-server

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,7 @@
     "@radix-ui/react-menubar": "^1.1.6",
     "@radix-ui/react-slot": "^1.1.1",
     "@radix-ui/react-switch": "^1.1.2",
+    "@radix-ui/react-toast": "^1.2.6",
     "@radix-ui/react-tooltip": "^1.1.7",
     "@stomp/stompjs": "^7.0.0",
     "@tanstack/react-query": "^5.65.1",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       '@radix-ui/react-switch':
         specifier: ^1.1.2
         version: 1.1.2(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-toast':
+        specifier: ^1.2.6
+        version: 1.2.6(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-tooltip':
         specifier: ^1.1.7
         version: 1.1.7(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1219,6 +1222,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-toast@1.2.6':
+    resolution: {integrity: sha512-gN4dpuIVKEgpLn1z5FhzT9mYRUitbfZq9XqN/7kkBMUgFTzTG8x/KszWJugJXHcwxckY8xcKDZPz7kG3o6DsUA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-tooltip@1.1.7':
     resolution: {integrity: sha512-ss0s80BC0+g0+Zc53MvilcnTYSOi4mSuFWBPYPuTOFGjx+pUU+ZrmamMNwS56t8MTFlniA5ocjd4jYm/CdhbOg==}
     peerDependencies:
@@ -1297,6 +1313,19 @@ packages:
 
   '@radix-ui/react-visually-hidden@1.1.1':
     resolution: {integrity: sha512-vVfA2IZ9q/J+gEamvj761Oq1FpWgCDaNOOIfbPVp2MVPLEomUr5+Vf7kJGwQ24YxZSlQVar7Bes8kyTo5Dshpg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-visually-hidden@1.1.2':
+    resolution: {integrity: sha512-1SzA4ns2M1aRlvxErqhLHsBHoS5eI5UUcI2awAMgGUp4LoaoWOKYmvqDY2s/tltuPkh3Yk77YF/r3IRj+Amx4Q==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -5378,6 +5407,26 @@ snapshots:
       '@types/react': 18.3.18
       '@types/react-dom': 18.3.5(@types/react@18.3.18)
 
+  '@radix-ui/react-toast@1.2.6(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.1
+      '@radix-ui/react-collection': 1.1.2(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@18.3.18)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.1(@types/react@18.3.18)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.1.5(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-portal': 1.1.4(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.2(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.2(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.3.18)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.18)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@18.3.18)(react@18.3.1)
+      '@radix-ui/react-visually-hidden': 1.1.2(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.18
+      '@types/react-dom': 18.3.5(@types/react@18.3.18)
+
   '@radix-ui/react-tooltip@1.1.7(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/primitive': 1.1.1
@@ -5447,6 +5496,15 @@ snapshots:
   '@radix-ui/react-visually-hidden@1.1.1(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-primitive': 2.0.1(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.18
+      '@types/react-dom': 18.3.5(@types/react@18.3.18)
+
+  '@radix-ui/react-visually-hidden@1.1.2(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.0.2(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import { router } from './routers';
 import { RouterProvider } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+import { Toaster } from '@/components/ui/toaster';
 
 const queryClient = new QueryClient({});
 
@@ -9,6 +10,7 @@ function App() {
   return (
     <QueryClientProvider client={queryClient}>
       <RouterProvider router={router} />
+      <Toaster />
       <ReactQueryDevtools initialIsOpen={false} position="bottom" />
     </QueryClientProvider>
   );

--- a/frontend/src/apis/user/index.ts
+++ b/frontend/src/apis/user/index.ts
@@ -14,7 +14,13 @@ export const postLogin = async (memberId: string) => {
   return data;
 };
 
-export const postRegister = async (username: string, email: string) => {
+export const postSignUp = async ({
+  username,
+  email,
+}: {
+  username: string;
+  email: string;
+}) => {
   const { data } = await userApi.post(`/api/auth/sign-up`, {
     username,
     email,

--- a/frontend/src/apis/user/index.ts
+++ b/frontend/src/apis/user/index.ts
@@ -1,32 +1,25 @@
 import { userApi, authApi, spaceApi } from '@/lib/clients';
 
-export const postLogin = async (email: string) => {
-  const signInResponse = await userApi.post(`/api/auth/sign-in`, {
+export const postSignIn = async (email: string) => {
+  const { data } = await userApi.post(`/api/auth/sign-in`, {
     email,
   });
+  return data;
+};
 
-  const { isMember, member } = signInResponse.data;
-
-  if (!isMember) return { signInResponse };
-
-  const issueTokenResponse = await authApi.post(`/api/auth/login`, {
-    userId: member.id,
+export const postLogin = async (memberId: string) => {
+  const { data } = await authApi.post(`/api/auth/login`, {
+    userId: memberId,
   });
-  if (issueTokenResponse.data.accessToken)
-    localStorage.setItem('access-token', issueTokenResponse.data.accessToken);
-
-  return { signInResponse, issueTokenResponse };
+  return data;
 };
 
 export const postRegister = async (username: string, email: string) => {
-  const registerResponse = await userApi.post(`/api/auth/sign-up`, {
+  const { data } = await userApi.post(`/api/auth/sign-up`, {
     username,
     email,
   });
-  if (registerResponse.data.code == '201') {
-    return await postLogin(email);
-  }
-  return registerResponse;
+  return data;
 };
 
 export const postRefreshToken = async () => {
@@ -34,17 +27,17 @@ export const postRefreshToken = async () => {
   return response;
 };
 
-export const postSendEmailCode = async (email: string) => {
-  await userApi.post(`/api/auth/send-code?email=${email}`);
-  return;
+export const postSendEmailCode = async (email: string): Promise<string> => {
+  const { data } = await userApi.post(`/api/auth/send-code?email=${email}`);
+  return data;
 };
 
 export const postConfirmEmail = async (email: string, code: string) => {
-  const response = await userApi.post(`/api/auth/certificate-email`, {
+  const { data } = await userApi.post(`/api/auth/certificate-email`, {
     email,
     code,
   });
-  return response;
+  return data;
 };
 
 export const getMyWorkspaceInfo = async (

--- a/frontend/src/components/login/EmailVerificationSection.tsx
+++ b/frontend/src/components/login/EmailVerificationSection.tsx
@@ -1,0 +1,28 @@
+import { InputCodeForm } from '@/components/login/InputCodeForm';
+import { Dispatch, SetStateAction } from 'react';
+
+const EmailVerificationSection = ({
+  code,
+  setCode,
+}: {
+  code: string;
+  setCode: Dispatch<SetStateAction<string>>;
+}) => {
+  return (
+    <>
+      <div className="text-center space-y-2">
+        <h1 className="text-3xl font-bold text-zinc-950">
+          코드는 이메일에서 확인하세요
+        </h1>
+        <p className="text-sm text-zinc-500">
+          코드는 잠시 후에 만료되니 서둘러 입력하세요.
+        </p>
+      </div>
+      <div className="flex justify-center items-center">
+        <InputCodeForm code={code} setCode={setCode} />
+      </div>
+    </>
+  );
+};
+
+export default EmailVerificationSection;

--- a/frontend/src/components/login/NickNameSettingSection.tsx
+++ b/frontend/src/components/login/NickNameSettingSection.tsx
@@ -1,0 +1,29 @@
+import { InputNicknameForm } from '@/components/login/InputNicknameForm';
+import { FormEvent } from 'react';
+
+const NickNameSettingSection = ({
+  email,
+  handleRegister,
+}: {
+  email: string;
+  handleRegister: (e: FormEvent<HTMLFormElement>) => Promise<void>;
+}) => {
+  return (
+    <>
+      <div className="text-center space-y-2">
+        <h1 className="text-3xl font-bold text-zinc-950">
+          닉네임을 입력해주세요
+        </h1>
+        <p className="text-sm text-zinc-500">
+          닉네임만 입력하면 회원가입이 끝나요!
+        </p>
+      </div>
+      <InputNicknameForm
+        onSubmit={handleRegister}
+        placeholder={email?.split('@')[0] || email}
+      />
+    </>
+  );
+};
+
+export default NickNameSettingSection;

--- a/frontend/src/components/modals/EmailSendingModal.tsx
+++ b/frontend/src/components/modals/EmailSendingModal.tsx
@@ -1,0 +1,14 @@
+import ModalPortal from '@/components/common/ModalPortal';
+
+const EmailSendingModal = () => {
+  return (
+    <ModalPortal>
+      <div className=" min-w-64 min-h-48 bg-white text-black flex flex-col items-center justify-center p-5 rounded-lg shadow-lg">
+        <div className="w-16 h-16 border-8 border-gray-300 border-t-yellow-500 rounded-full animate-spin"></div>
+        <p className="mt-3 text-lg font-medium">이메일 전송 중...</p>
+      </div>
+    </ModalPortal>
+  );
+};
+
+export default EmailSendingModal;

--- a/frontend/src/components/ui/toast.tsx
+++ b/frontend/src/components/ui/toast.tsx
@@ -1,0 +1,127 @@
+import * as React from "react"
+import * as ToastPrimitives from "@radix-ui/react-toast"
+import { cva, type VariantProps } from "class-variance-authority"
+import { X } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const ToastProvider = ToastPrimitives.Provider
+
+const ToastViewport = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Viewport>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Viewport>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Viewport
+    ref={ref}
+    className={cn(
+      "fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]",
+      className
+    )}
+    {...props}
+  />
+))
+ToastViewport.displayName = ToastPrimitives.Viewport.displayName
+
+const toastVariants = cva(
+  "group pointer-events-auto relative flex w-full items-center justify-between space-x-2 overflow-hidden rounded-md border p-4 pr-6 shadow-lg transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-top-full data-[state=open]:sm:slide-in-from-bottom-full",
+  {
+    variants: {
+      variant: {
+        default: "border bg-background text-foreground",
+        destructive:
+          "destructive group border-destructive bg-destructive text-destructive-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+const Toast = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Root>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Root> &
+    VariantProps<typeof toastVariants>
+>(({ className, variant, ...props }, ref) => {
+  return (
+    <ToastPrimitives.Root
+      ref={ref}
+      className={cn(toastVariants({ variant }), className)}
+      {...props}
+    />
+  )
+})
+Toast.displayName = ToastPrimitives.Root.displayName
+
+const ToastAction = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Action>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Action>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Action
+    ref={ref}
+    className={cn(
+      "inline-flex h-8 shrink-0 items-center justify-center rounded-md border bg-transparent px-3 text-sm font-medium transition-colors hover:bg-secondary focus:outline-none focus:ring-1 focus:ring-ring disabled:pointer-events-none disabled:opacity-50 group-[.destructive]:border-muted/40 group-[.destructive]:hover:border-destructive/30 group-[.destructive]:hover:bg-destructive group-[.destructive]:hover:text-destructive-foreground group-[.destructive]:focus:ring-destructive",
+      className
+    )}
+    {...props}
+  />
+))
+ToastAction.displayName = ToastPrimitives.Action.displayName
+
+const ToastClose = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Close>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Close>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Close
+    ref={ref}
+    className={cn(
+      "absolute right-1 top-1 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-1 group-hover:opacity-100 group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600",
+      className
+    )}
+    toast-close=""
+    {...props}
+  >
+    <X className="h-4 w-4" />
+  </ToastPrimitives.Close>
+))
+ToastClose.displayName = ToastPrimitives.Close.displayName
+
+const ToastTitle = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Title>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Title>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Title
+    ref={ref}
+    className={cn("text-sm font-semibold [&+div]:text-xs", className)}
+    {...props}
+  />
+))
+ToastTitle.displayName = ToastPrimitives.Title.displayName
+
+const ToastDescription = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Description>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Description>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Description
+    ref={ref}
+    className={cn("text-sm opacity-90", className)}
+    {...props}
+  />
+))
+ToastDescription.displayName = ToastPrimitives.Description.displayName
+
+type ToastProps = React.ComponentPropsWithoutRef<typeof Toast>
+
+type ToastActionElement = React.ReactElement<typeof ToastAction>
+
+export {
+  type ToastProps,
+  type ToastActionElement,
+  ToastProvider,
+  ToastViewport,
+  Toast,
+  ToastTitle,
+  ToastDescription,
+  ToastClose,
+  ToastAction,
+}

--- a/frontend/src/components/ui/toaster.tsx
+++ b/frontend/src/components/ui/toaster.tsx
@@ -1,0 +1,33 @@
+import { useToast } from "@/hooks/use-toast"
+import {
+  Toast,
+  ToastClose,
+  ToastDescription,
+  ToastProvider,
+  ToastTitle,
+  ToastViewport,
+} from "@/components/ui/toast"
+
+export function Toaster() {
+  const { toasts } = useToast()
+
+  return (
+    <ToastProvider>
+      {toasts.map(function ({ id, title, description, action, ...props }) {
+        return (
+          <Toast key={id} {...props}>
+            <div className="grid gap-1">
+              {title && <ToastTitle>{title}</ToastTitle>}
+              {description && (
+                <ToastDescription>{description}</ToastDescription>
+              )}
+            </div>
+            {action}
+            <ToastClose />
+          </Toast>
+        )
+      })}
+      <ToastViewport />
+    </ToastProvider>
+  )
+}

--- a/frontend/src/hooks/auth/useAuth.ts
+++ b/frontend/src/hooks/auth/useAuth.ts
@@ -1,4 +1,5 @@
 import { useLoginMutation } from '@/hooks/auth/useAuthMutations';
+import { useToast } from '@/hooks/use-toast';
 import { userOriginStore } from '@/stores/userOriginStore';
 import { useUserStore } from '@/stores/userStore';
 import { useNavigate } from 'react-router';
@@ -6,6 +7,7 @@ import { useNavigate } from 'react-router';
 export const useAuth = () => {
   const { setUser: setOriginUser } = userOriginStore();
   const { setUser } = useUserStore();
+  const { toast } = useToast();
 
   const login = useLoginMutation();
   const navigate = useNavigate();
@@ -20,7 +22,7 @@ export const useAuth = () => {
     await login.mutateAsync(member.id).then(({ accessToken }) => {
       if (accessToken) localStorage.setItem('access-token', accessToken);
       else {
-        alert('accessToken 발급 실패');
+        toast({ title: 'accessToken 발급 실패' });
         return;
       }
       const userInfo = member;
@@ -28,8 +30,9 @@ export const useAuth = () => {
       setUser({
         userId: userInfo.id,
       });
-      // toast로 대체
-      alert('성공');
+      toast({
+        title: `로그인 성공`,
+      });
       navigate('/workspaces');
     });
   };

--- a/frontend/src/hooks/auth/useAuth.ts
+++ b/frontend/src/hooks/auth/useAuth.ts
@@ -1,8 +1,8 @@
-import { useLoginMutation } from '@/hooks/auth/useAuthMutations';
-import { useToast } from '@/hooks/use-toast';
+import { useNavigate } from 'react-router';
 import { userOriginStore } from '@/stores/userOriginStore';
 import { useUserStore } from '@/stores/userStore';
-import { useNavigate } from 'react-router';
+import { useLoginMutation } from '@/hooks/auth/useAuthMutations';
+import { useToast } from '@/hooks/use-toast';
 
 export const useAuth = () => {
   const { setUser: setOriginUser } = userOriginStore();
@@ -12,7 +12,7 @@ export const useAuth = () => {
   const login = useLoginMutation();
   const navigate = useNavigate();
 
-  const handleLogin = async (member: {
+  const loginWithMember = async (member: {
     id: string;
     username: string;
     email: string;
@@ -37,5 +37,5 @@ export const useAuth = () => {
     });
   };
 
-  return { handleLogin };
+  return { loginWithMember };
 };

--- a/frontend/src/hooks/auth/useAuth.ts
+++ b/frontend/src/hooks/auth/useAuth.ts
@@ -1,0 +1,38 @@
+import { useLoginMutation } from '@/hooks/auth/useAuthMutations';
+import { userOriginStore } from '@/stores/userOriginStore';
+import { useUserStore } from '@/stores/userStore';
+import { useNavigate } from 'react-router';
+
+export const useAuth = () => {
+  const { setUser: setOriginUser } = userOriginStore();
+  const { setUser } = useUserStore();
+
+  const login = useLoginMutation();
+  const navigate = useNavigate();
+
+  const handleLogin = async (member: {
+    id: string;
+    username: string;
+    email: string;
+    createdAt: string;
+    updatedAt: string;
+  }) => {
+    await login.mutateAsync(member.id).then(({ accessToken }) => {
+      if (accessToken) localStorage.setItem('access-token', accessToken);
+      else {
+        alert('accessToken 발급 실패');
+        return;
+      }
+      const userInfo = member;
+      setOriginUser(userInfo);
+      setUser({
+        userId: userInfo.id,
+      });
+      // toast로 대체
+      alert('성공');
+      navigate('/workspaces');
+    });
+  };
+
+  return { handleLogin };
+};

--- a/frontend/src/hooks/auth/useAuthMutations.ts
+++ b/frontend/src/hooks/auth/useAuthMutations.ts
@@ -1,0 +1,17 @@
+import { postLogin, postSignIn, postSignUp } from '@/apis/user';
+import { useMutation } from '@tanstack/react-query';
+
+export const useSignInMutation = () =>
+  useMutation({
+    mutationFn: postSignIn,
+  });
+
+export const useSignUpMutation = () =>
+  useMutation({
+    mutationFn: postSignUp,
+  });
+
+export const useLoginMutation = () =>
+  useMutation({
+    mutationFn: postLogin,
+  });

--- a/frontend/src/hooks/auth/useEmailMutation.ts
+++ b/frontend/src/hooks/auth/useEmailMutation.ts
@@ -1,0 +1,15 @@
+import { postConfirmEmail, postSendEmailCode } from '@/apis/user';
+import { useMutation } from '@tanstack/react-query';
+
+export const useSendEmailMutation = () => {
+  return useMutation({
+    mutationFn: postSendEmailCode,
+  });
+};
+
+export const useConfirmEmailMutation = () => {
+  return useMutation({
+    mutationFn: ({ email, code }: { email: string; code: string }) =>
+      postConfirmEmail(email, code),
+  });
+};

--- a/frontend/src/hooks/auth/useSendEmailMutation.ts
+++ b/frontend/src/hooks/auth/useSendEmailMutation.ts
@@ -1,9 +1,0 @@
-import { postSendEmailCode } from '@/apis/user';
-import { useMutation } from '@tanstack/react-query';
-
-export const useSendEmailMutation = () => {
-  const { mutate: sendEmail, isPending: sendEmailIsPending } = useMutation({
-    mutationFn: postSendEmailCode,
-  });
-  return { sendEmail, sendEmailIsPending };
-};

--- a/frontend/src/hooks/auth/useSendEmailMutation.ts
+++ b/frontend/src/hooks/auth/useSendEmailMutation.ts
@@ -1,0 +1,9 @@
+import { postSendEmailCode } from '@/apis/user';
+import { useMutation } from '@tanstack/react-query';
+
+export const useSendEmailMutation = () => {
+  const { mutate: sendEmail, isPending: sendEmailIsPending } = useMutation({
+    mutationFn: postSendEmailCode,
+  });
+  return { sendEmail, sendEmailIsPending };
+};

--- a/frontend/src/hooks/use-toast.ts
+++ b/frontend/src/hooks/use-toast.ts
@@ -1,0 +1,191 @@
+'use client';
+
+// Inspired by react-hot-toast library
+import * as React from 'react';
+
+import type { ToastActionElement, ToastProps } from '@/components/ui/toast';
+
+const TOAST_LIMIT = 1;
+const TOAST_REMOVE_DELAY = 1000000;
+
+type ToasterToast = ToastProps & {
+  id: string;
+  title?: React.ReactNode;
+  description?: React.ReactNode;
+  action?: ToastActionElement;
+};
+
+const actionTypes = {
+  ADD_TOAST: 'ADD_TOAST',
+  UPDATE_TOAST: 'UPDATE_TOAST',
+  DISMISS_TOAST: 'DISMISS_TOAST',
+  REMOVE_TOAST: 'REMOVE_TOAST',
+} as const;
+
+let count = 0;
+
+function genId() {
+  count = (count + 1) % Number.MAX_SAFE_INTEGER;
+  return count.toString();
+}
+
+type ActionType = typeof actionTypes;
+
+type Action =
+  | {
+      type: ActionType['ADD_TOAST'];
+      toast: ToasterToast;
+    }
+  | {
+      type: ActionType['UPDATE_TOAST'];
+      toast: Partial<ToasterToast>;
+    }
+  | {
+      type: ActionType['DISMISS_TOAST'];
+      toastId?: ToasterToast['id'];
+    }
+  | {
+      type: ActionType['REMOVE_TOAST'];
+      toastId?: ToasterToast['id'];
+    };
+
+interface State {
+  toasts: ToasterToast[];
+}
+
+const toastTimeouts = new Map<string, ReturnType<typeof setTimeout>>();
+
+const addToRemoveQueue = (toastId: string) => {
+  if (toastTimeouts.has(toastId)) {
+    return;
+  }
+
+  const timeout = setTimeout(() => {
+    toastTimeouts.delete(toastId);
+    dispatch({
+      type: 'REMOVE_TOAST',
+      toastId: toastId,
+    });
+  }, TOAST_REMOVE_DELAY);
+
+  toastTimeouts.set(toastId, timeout);
+};
+
+export const reducer = (state: State, action: Action): State => {
+  switch (action.type) {
+    case 'ADD_TOAST':
+      return {
+        ...state,
+        toasts: [action.toast, ...state.toasts].slice(0, TOAST_LIMIT),
+      };
+
+    case 'UPDATE_TOAST':
+      return {
+        ...state,
+        toasts: state.toasts.map(t =>
+          t.id === action.toast.id ? { ...t, ...action.toast } : t
+        ),
+      };
+
+    case 'DISMISS_TOAST': {
+      const { toastId } = action;
+
+      // ! Side effects ! - This could be extracted into a dismissToast() action,
+      // but I'll keep it here for simplicity
+      if (toastId) {
+        addToRemoveQueue(toastId);
+      } else {
+        state.toasts.forEach(toast => {
+          addToRemoveQueue(toast.id);
+        });
+      }
+
+      return {
+        ...state,
+        toasts: state.toasts.map(t =>
+          t.id === toastId || toastId === undefined
+            ? {
+                ...t,
+                open: false,
+              }
+            : t
+        ),
+      };
+    }
+    case 'REMOVE_TOAST':
+      if (action.toastId === undefined) {
+        return {
+          ...state,
+          toasts: [],
+        };
+      }
+      return {
+        ...state,
+        toasts: state.toasts.filter(t => t.id !== action.toastId),
+      };
+  }
+};
+
+const listeners: Array<(state: State) => void> = [];
+
+let memoryState: State = { toasts: [] };
+
+function dispatch(action: Action) {
+  memoryState = reducer(memoryState, action);
+  listeners.forEach(listener => {
+    listener(memoryState);
+  });
+}
+
+type Toast = Omit<ToasterToast, 'id'>;
+
+function toast({ ...props }: Toast) {
+  const id = genId();
+
+  const update = (props: ToasterToast) =>
+    dispatch({
+      type: 'UPDATE_TOAST',
+      toast: { ...props, id },
+    });
+  const dismiss = () => dispatch({ type: 'DISMISS_TOAST', toastId: id });
+
+  dispatch({
+    type: 'ADD_TOAST',
+    toast: {
+      ...props,
+      id,
+      open: true,
+      onOpenChange: open => {
+        if (!open) dismiss();
+      },
+    },
+  });
+
+  return {
+    id: id,
+    dismiss,
+    update,
+  };
+}
+
+function useToast() {
+  const [state, setState] = React.useState<State>(memoryState);
+
+  React.useEffect(() => {
+    listeners.push(setState);
+    return () => {
+      const index = listeners.indexOf(setState);
+      if (index > -1) {
+        listeners.splice(index, 1);
+      }
+    };
+  }, [state]);
+
+  return {
+    ...state,
+    toast,
+    dismiss: (toastId?: string) => dispatch({ type: 'DISMISS_TOAST', toastId }),
+  };
+}
+
+export { useToast, toast };

--- a/frontend/src/pages/login/ConfirmEmailPage.tsx
+++ b/frontend/src/pages/login/ConfirmEmailPage.tsx
@@ -25,32 +25,38 @@ const ConfirmEmailPage = () => {
   const handleLogin = async () => {
     if (!email) {
       alert('이메일을 다시 전송해주세요.');
-      navigate('/');
       return;
     }
 
-    const confirmResponse = await postConfirmEmail(email, code);
-
-    if (confirmResponse.code === '400') {
-      alert(confirmResponse.message);
-      return;
-    }
-
-    if (confirmResponse.code === '200') {
-      const { isMember, member } = await postSignIn(email);
-      if (isMember === false) {
-        setIsRegistering(true);
-      } else {
-        const { accessToken } = await postLogin(member.id);
-        if (accessToken) localStorage.setItem('access-token', accessToken);
-        const userInfo = member;
-        setOriginUser(userInfo);
-        setUser({
-          userId: userInfo.id,
-        });
-        alert('성공');
-        navigate('/workspaces');
+    try {
+      const confirmResponse = await postConfirmEmail(email, code);
+      if (confirmResponse.code === '400') {
+        alert(confirmResponse.message);
+        return;
       }
+
+      if (confirmResponse.code === '200') {
+        const { isMember, member } = await postSignIn(email);
+        if (isMember === false) setIsRegistering(true);
+        else {
+          const { accessToken } = await postLogin(member.id);
+          if (accessToken) localStorage.setItem('access-token', accessToken);
+          else {
+            alert('accessToken 발급 실패');
+            return;
+          }
+          const userInfo = member;
+          setOriginUser(userInfo);
+          setUser({
+            userId: userInfo.id,
+          });
+          alert('성공');
+          navigate('/workspaces');
+        }
+      }
+    } catch (error) {
+      alert('코드 확인에 실패했습니다.');
+      return;
     }
   };
 

--- a/frontend/src/pages/login/ConfirmEmailPage.tsx
+++ b/frontend/src/pages/login/ConfirmEmailPage.tsx
@@ -2,7 +2,7 @@
 import {
   postConfirmEmail,
   postLogin,
-  postRegister,
+  postSignUp,
   postSignIn,
 } from '@/apis/user';
 import { InputCodeForm } from '@/components/login/InputCodeForm';
@@ -59,15 +59,17 @@ const ConfirmEmailPage = () => {
     const formData = new FormData(e.currentTarget);
     const name = String(formData.get('name'));
     try {
-      await postRegister(name, email);
+      await postSignUp({ username: name, email });
       const { member } = await postSignIn(email);
       const { accessToken } = await postLogin(member.id);
       if (accessToken) localStorage.setItem('access-token', accessToken);
+      else alert('accessToken 발급 실패');
       const userInfo = member;
       setOriginUser(userInfo);
       setUser({
         userId: userInfo.id,
       });
+      alert('성공');
       navigate('/workspaces');
     } catch (error) {
       alert('회원가입에 실패했습니다.');

--- a/frontend/src/pages/login/ConfirmEmailPage.tsx
+++ b/frontend/src/pages/login/ConfirmEmailPage.tsx
@@ -18,7 +18,7 @@ const ConfirmEmailPage = () => {
   const signUp = useSignUpMutation();
   const signIn = useSignInMutation();
   const confirmEmail = useConfirmEmailMutation();
-  const { handleLogin } = useAuth();
+  const { loginWithMember } = useAuth();
 
   const { toast } = useToast();
 
@@ -39,7 +39,7 @@ const ConfirmEmailPage = () => {
       if (confirmResponse.code === '200') {
         const { isMember, member } = await signIn.mutateAsync(email);
         if (isMember === false) setIsRegistering(true);
-        else await handleLogin(member);
+        else await loginWithMember(member);
       }
     } catch (error) {
       toast({
@@ -56,7 +56,7 @@ const ConfirmEmailPage = () => {
     try {
       await signUp.mutateAsync({ username: name, email });
       const { member } = await signIn.mutateAsync(email);
-      await handleLogin(member);
+      await loginWithMember(member);
     } catch (error) {
       toast({
         title: `회원가입에 실패했습니다. ${error}`,

--- a/frontend/src/pages/login/ConfirmEmailPage.tsx
+++ b/frontend/src/pages/login/ConfirmEmailPage.tsx
@@ -8,6 +8,7 @@ import {
 } from '@/hooks/auth/useAuthMutations';
 import { useConfirmEmailMutation } from '@/hooks/auth/useEmailMutation';
 import { useAuth } from '@/hooks/auth/useAuth';
+import { useToast } from '@/hooks/use-toast';
 
 const ConfirmEmailPage = () => {
   const location = useLocation();
@@ -19,11 +20,15 @@ const ConfirmEmailPage = () => {
   const confirmEmail = useConfirmEmailMutation();
   const { handleLogin } = useAuth();
 
+  const { toast } = useToast();
+
   const email = location.state?.email;
 
   const submitInput = async () => {
     if (!email) {
-      alert('이메일을 입력해주세요.');
+      toast({
+        title: '이메일을 입력해주세요',
+      });
       return;
     }
 
@@ -37,7 +42,9 @@ const ConfirmEmailPage = () => {
         else await handleLogin(member);
       }
     } catch (error) {
-      alert(`코드 확인에 실패했습니다. ${error}`);
+      toast({
+        title: `코드 확인에 실패했습니다. ${error}`,
+      });
       return;
     }
   };
@@ -51,7 +58,9 @@ const ConfirmEmailPage = () => {
       const { member } = await signIn.mutateAsync(email);
       await handleLogin(member);
     } catch (error) {
-      alert(`회원가입에 실패했습니다. ${error}`);
+      toast({
+        title: `회원가입에 실패했습니다. ${error}`,
+      });
     }
   };
 

--- a/frontend/src/pages/login/ConfirmEmailPage.tsx
+++ b/frontend/src/pages/login/ConfirmEmailPage.tsx
@@ -1,61 +1,43 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
-import {
-  postConfirmEmail,
-  postLogin,
-  postSignUp,
-  postSignIn,
-} from '@/apis/user';
-import { InputCodeForm } from '@/components/login/InputCodeForm';
-import { InputNicknameForm } from '@/components/login/InputNicknameForm';
-import { userOriginStore } from '@/stores/userOriginStore';
-import { useUserStore } from '@/stores/userStore';
 import { FormEvent, useEffect, useState } from 'react';
-import { useLocation, useNavigate } from 'react-router';
+import { useLocation } from 'react-router';
+import EmailVerificationSection from '@/components/login/EmailVerificationSection';
+import NickNameSettingSection from '@/components/login/NickNameSettingSection';
+import {
+  useSignInMutation,
+  useSignUpMutation,
+} from '@/hooks/auth/useAuthMutations';
+import { useConfirmEmailMutation } from '@/hooks/auth/useEmailMutation';
+import { useAuth } from '@/hooks/auth/useAuth';
 
 const ConfirmEmailPage = () => {
-  const navigate = useNavigate();
   const location = useLocation();
   const [code, setCode] = useState('');
   const [isRegistering, setIsRegistering] = useState(false);
-  const { setUser: setOriginUser } = userOriginStore();
-  const { setUser } = useUserStore();
+
+  const signUp = useSignUpMutation();
+  const signIn = useSignInMutation();
+  const confirmEmail = useConfirmEmailMutation();
+  const { handleLogin } = useAuth();
 
   const email = location.state?.email;
 
-  const handleLogin = async () => {
+  const submitInput = async () => {
     if (!email) {
-      alert('이메일을 다시 전송해주세요.');
+      alert('이메일을 입력해주세요.');
       return;
     }
 
     try {
-      const confirmResponse = await postConfirmEmail(email, code);
-      if (confirmResponse.code === '400') {
-        alert(confirmResponse.message);
-        return;
-      }
-
+      const confirmResponse = await confirmEmail.mutateAsync({ email, code });
+      if (confirmResponse.code === '400')
+        throw new Error(confirmResponse.message);
       if (confirmResponse.code === '200') {
-        const { isMember, member } = await postSignIn(email);
+        const { isMember, member } = await signIn.mutateAsync(email);
         if (isMember === false) setIsRegistering(true);
-        else {
-          const { accessToken } = await postLogin(member.id);
-          if (accessToken) localStorage.setItem('access-token', accessToken);
-          else {
-            alert('accessToken 발급 실패');
-            return;
-          }
-          const userInfo = member;
-          setOriginUser(userInfo);
-          setUser({
-            userId: userInfo.id,
-          });
-          alert('성공');
-          navigate('/workspaces');
-        }
+        else await handleLogin(member);
       }
     } catch (error) {
-      alert('코드 확인에 실패했습니다.');
+      alert(`코드 확인에 실패했습니다. ${error}`);
       return;
     }
   };
@@ -65,30 +47,16 @@ const ConfirmEmailPage = () => {
     const formData = new FormData(e.currentTarget);
     const name = String(formData.get('name'));
     try {
-      await postSignUp({ username: name, email });
-      const { member } = await postSignIn(email);
-      const { accessToken } = await postLogin(member.id);
-      if (accessToken) localStorage.setItem('access-token', accessToken);
-      else alert('accessToken 발급 실패');
-      const userInfo = member;
-      setOriginUser(userInfo);
-      setUser({
-        userId: userInfo.id,
-      });
-      alert('성공');
-      navigate('/workspaces');
+      await signUp.mutateAsync({ username: name, email });
+      const { member } = await signIn.mutateAsync(email);
+      await handleLogin(member);
     } catch (error) {
-      alert('회원가입에 실패했습니다.');
+      alert(`회원가입에 실패했습니다. ${error}`);
     }
   };
+
   useEffect(() => {
-    if (code.length === 6) {
-      try {
-        handleLogin();
-      } catch (e) {
-        alert('로그인 실패');
-      }
-    }
+    if (code.length === 6) submitInput();
   }, [code]);
 
   return (
@@ -96,34 +64,12 @@ const ConfirmEmailPage = () => {
       <div className="text-2xl font-bold text-zinc-950 mb-8">smileTogether</div>
       <div className="w-full max-w-md space-y-6">
         {!isRegistering ? (
-          <>
-            <div className="text-center space-y-2">
-              <h1 className="text-3xl font-bold text-zinc-950">
-                코드는 이메일에서 확인하세요
-              </h1>
-              <p className="text-sm text-zinc-500">
-                코드는 잠시 후에 만료되니 서둘러 입력하세요.
-              </p>
-            </div>
-            <div className="flex justify-center items-center">
-              <InputCodeForm code={code} setCode={setCode} />
-            </div>
-          </>
+          <EmailVerificationSection code={code} setCode={setCode} />
         ) : (
-          <>
-            <div className="text-center space-y-2">
-              <h1 className="text-3xl font-bold text-zinc-950">
-                닉네임을 입력해주세요
-              </h1>
-              <p className="text-sm text-zinc-500">
-                닉네임만 입력하면 회원가입이 끝나요!
-              </p>
-            </div>
-            <InputNicknameForm
-              onSubmit={handleRegister}
-              placeholder={email?.split('@')[0] || email}
-            />
-          </>
+          <NickNameSettingSection
+            email={email}
+            handleRegister={handleRegister}
+          />
         )}
       </div>
     </div>

--- a/frontend/src/pages/login/LoginPage.tsx
+++ b/frontend/src/pages/login/LoginPage.tsx
@@ -10,15 +10,13 @@ const LoginPage = () => {
   const handleEmailSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     const formData = new FormData(e.currentTarget);
-    const email = formData.get('email') as string;
+    const email = String(formData.get('email'));
     if (!email) {
       alert('이메일을 입력해주세요.');
       return;
     }
     sendEmail(email, {
-      onSuccess: () => {
-        navigate('/confirmemail', { state: { email } });
-      },
+      onSuccess: () => navigate('/confirmemail', { state: { email } }),
     });
   };
 

--- a/frontend/src/pages/login/LoginPage.tsx
+++ b/frontend/src/pages/login/LoginPage.tsx
@@ -2,11 +2,11 @@ import ModalPortal from '@/components/common/ModalPortal';
 import { LoginForm } from '@/components/login/LoginForm';
 import { FormEvent } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useSendEmailMutation } from '@/hooks/auth/useSendEmailMutation';
+import { useSendEmailMutation } from '@/hooks/auth/useEmailMutation';
 
 const LoginPage = () => {
   const navigate = useNavigate();
-  const { sendEmail, sendEmailIsPending } = useSendEmailMutation();
+  const sendEmail = useSendEmailMutation();
   const handleEmailSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     const formData = new FormData(e.currentTarget);
@@ -15,7 +15,7 @@ const LoginPage = () => {
       alert('이메일을 입력해주세요.');
       return;
     }
-    sendEmail(email, {
+    sendEmail.mutate(email, {
       onSuccess: () => navigate('/confirmemail', { state: { email } }),
     });
   };
@@ -38,7 +38,7 @@ const LoginPage = () => {
           <LoginForm onSubmit={handleEmailSubmit} />
         </div>
       </div>
-      {sendEmailIsPending && (
+      {sendEmail.isPending && (
         <ModalPortal>
           <div className=" min-w-64 min-h-48 bg-white text-black flex flex-col items-center justify-center p-5 rounded-lg shadow-lg">
             <div className="w-16 h-16 border-8 border-gray-300 border-t-yellow-500 rounded-full animate-spin"></div>

--- a/frontend/src/pages/login/LoginPage.tsx
+++ b/frontend/src/pages/login/LoginPage.tsx
@@ -3,16 +3,18 @@ import { LoginForm } from '@/components/login/LoginForm';
 import { FormEvent } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useSendEmailMutation } from '@/hooks/auth/useEmailMutation';
+import { useToast } from '@/hooks/use-toast';
 
 const LoginPage = () => {
   const navigate = useNavigate();
   const sendEmail = useSendEmailMutation();
+  const { toast } = useToast();
   const handleEmailSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     const formData = new FormData(e.currentTarget);
     const email = String(formData.get('email'));
     if (!email) {
-      alert('이메일을 입력해주세요.');
+      toast({ title: '이메일을 입력해주세요' });
       return;
     }
     sendEmail.mutate(email, {

--- a/frontend/src/pages/login/LoginPage.tsx
+++ b/frontend/src/pages/login/LoginPage.tsx
@@ -1,7 +1,7 @@
-import ModalPortal from '@/components/common/ModalPortal';
-import { LoginForm } from '@/components/login/LoginForm';
 import { FormEvent } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { LoginForm } from '@/components/login/LoginForm';
+import EmailSendingModal from '@/components/modals/EmailSendingModal';
 import { useSendEmailMutation } from '@/hooks/auth/useEmailMutation';
 import { useToast } from '@/hooks/use-toast';
 
@@ -40,14 +40,7 @@ const LoginPage = () => {
           <LoginForm onSubmit={handleEmailSubmit} />
         </div>
       </div>
-      {sendEmail.isPending && (
-        <ModalPortal>
-          <div className=" min-w-64 min-h-48 bg-white text-black flex flex-col items-center justify-center p-5 rounded-lg shadow-lg">
-            <div className="w-16 h-16 border-8 border-gray-300 border-t-yellow-500 rounded-full animate-spin"></div>
-            <p className="mt-3 text-lg font-medium">이메일 전송 중...</p>
-          </div>
-        </ModalPortal>
-      )}
+      {sendEmail.isPending && <EmailSendingModal />}
     </>
   );
 };

--- a/frontend/src/pages/login/LoginPage.tsx
+++ b/frontend/src/pages/login/LoginPage.tsx
@@ -1,53 +1,54 @@
-import { postSendEmailCode } from '@/apis/user';
 import ModalPortal from '@/components/common/ModalPortal';
 import { LoginForm } from '@/components/login/LoginForm';
-import { FormEvent, useState } from 'react';
+import { FormEvent } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useSendEmailMutation } from '@/hooks/auth/useSendEmailMutation';
 
 const LoginPage = () => {
-  const [isLoading, setIsLoading] = useState(false);
-
   const navigate = useNavigate();
-
+  const { sendEmail, sendEmailIsPending } = useSendEmailMutation();
   const handleEmailSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    //이메일 전송
     const formData = new FormData(e.currentTarget);
     const email = formData.get('email') as string;
-    try {
-      setIsLoading(true);
-      await postSendEmailCode(email);
-      navigate('/confirmemail', { state: { email: email } });
-      setIsLoading(false);
-    } catch (error) {
-      setIsLoading(false);
-      alert('이메일 전송에 실패했습니다.');
+    if (!email) {
+      alert('이메일을 입력해주세요.');
+      return;
     }
+    sendEmail(email, {
+      onSuccess: () => {
+        navigate('/confirmemail', { state: { email } });
+      },
+    });
   };
 
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center bg-white p-4">
-      <div className="text-2xl font-bold text-zinc-950 mb-8">smileTogether</div>
-      <div className="w-full max-w-md space-y-6">
-        <div className="text-center space-y-2">
-          {isLoading && (
-            <ModalPortal>
-              <div className=" min-w-64 min-h-48 bg-white text-black flex flex-col items-center justify-center p-5 rounded-lg shadow-lg">
-                <div className="w-16 h-16 border-8 border-gray-300 border-t-yellow-500 rounded-full animate-spin"></div>
-                <p className="mt-3 text-lg font-medium">이메일 전송 중...</p>
-              </div>
-            </ModalPortal>
-          )}
-          <h1 className="text-3xl font-bold text-zinc-950">
-            먼저 이메일부터 입력해 보세요
-          </h1>
-          <p className="text-sm text-zinc-500">
-            직장에서 사용하는 이메일 주소로 로그인하는 걸 추천드려요.
-          </p>
+    <>
+      <div className="min-h-screen flex flex-col items-center justify-center bg-white p-4">
+        <div className="text-2xl font-bold text-zinc-950 mb-8">
+          smileTogether
         </div>
-        <LoginForm onSubmit={handleEmailSubmit} />
+        <div className="w-full max-w-md space-y-6">
+          <div className="text-center space-y-2">
+            <h1 className="text-3xl font-bold text-zinc-950">
+              먼저 이메일부터 입력해 보세요
+            </h1>
+            <p className="text-sm text-zinc-500">
+              직장에서 사용하는 이메일 주소로 로그인하는 걸 추천드려요.
+            </p>
+          </div>
+          <LoginForm onSubmit={handleEmailSubmit} />
+        </div>
       </div>
-    </div>
+      {sendEmailIsPending && (
+        <ModalPortal>
+          <div className=" min-w-64 min-h-48 bg-white text-black flex flex-col items-center justify-center p-5 rounded-lg shadow-lg">
+            <div className="w-16 h-16 border-8 border-gray-300 border-t-yellow-500 rounded-full animate-spin"></div>
+            <p className="mt-3 text-lg font-medium">이메일 전송 중...</p>
+          </div>
+        </ModalPortal>
+      )}
+    </>
   );
 };
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #213 
## 📝리팩터링 내용 

- **유저 API 모듈 (`user/api/index.ts`)** 에서 단일 책임 원칙 위반 해결
- **이메일 인증 흐름 (ConfirmEmailPage)** UI 및 로직 개선
- **LoginPage**에서 React Query 도입 및 비즈니스 로직 개선

### 기존 문제점

- 유저 API에 비즈니스 로직이 혼재되어 있어 **역할 분리**가 되지 않았음
- 반복되는 로직 및 부족한 예외 처리로 인해 유지보수가 어려움
- 기본 `alert` 사용으로 **사용자 경험이 부족**하고 통일성 없는 UI 제공

## Login 페이지 리팩토링
- 기존 `axios` 직접 호출 → `React Query`의 `useMutation`으로 대체
- 로딩 상태 관리를 위해 `isLoading` state 제거 → `mutation.isPending`으로 통합
- 이메일 미입력 시 처리 로직 추가
- FormData의 입력값을 `as string`에서 `String()`으로 변환
  - `as string`은 타입 단언에 불과해 null일 경우 런타임 에러 발생 위험
  - `String()`을 사용하면 실제 문자열로 변환되어 더 안전한 입력 처리 가능

## Confirm 페이지 리팩토링
### Confirm 페이지 기존 로직
<img width="764" alt="Image" src="https://github.com/user-attachments/assets/cdd54d53-e709-4f81-8366-ddbd41db9563" />

### 1차 수정 후 로직
<img width="688" alt="Image" src="https://github.com/user-attachments/assets/a92a5bed-10de-4507-ab07-c390998c8f29" />

- 로그인 / 회원가입 / 이메일 인증 로직이 하나의 흐름으로 뭉쳐 있던 코드를 기능별로 분리
- **공통 로직 추출** 및 **관심사 분리**를 통해 유지보수성과 테스트 용이성 향상

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
