### PR TITLE
[FE] Fix : 워크스페이스 접속 시 MainNavigationSidebar 의 DM 클릭 시 Sidebar 가 DM 리스트로 바뀌는 문제

### DIFF
--- a/frontend/src/components/frame/workspace/MainNavigationSidebar.tsx
+++ b/frontend/src/components/frame/workspace/MainNavigationSidebar.tsx
@@ -1,6 +1,7 @@
 import WorkspaceIconButton from '@/components/workspace/WorkspaceIconButton';
 import { NAVIGATION_ICONS } from '@/constants/navItems';
 import useWorkspaceChannelListQuery from '@/hooks/channel/useWorkspaceChannelListQuery';
+import useIsDmSideBarStore from '@/stores/isDm';
 import { useNavigate, useParams } from 'react-router';
 
 const MainNavigationSidebar = () => {
@@ -8,7 +9,7 @@ const MainNavigationSidebar = () => {
   const navigate = useNavigate();
   const { workspaceId } = useParams();
   const { channelList } = useWorkspaceChannelListQuery(workspaceId!);
-
+  const { setIsDmSideBar } = useIsDmSideBarStore();
   return (
     <div className="flex flex-col items-center py-3 text-white bg-yellow-300 border-r-2  min-w-16">
       {icons.map((item, index) => {
@@ -19,12 +20,14 @@ const MainNavigationSidebar = () => {
             onClick={() => {
               if (item.type === 'Home') {
                 if (channelList && channelList.length > 0) {
+                  setIsDmSideBar(false);
                   navigate(
                     `/workspace/${workspaceId}/channel/${channelList[0].channelId}`
                   );
                 }
               }
               if (item.type === 'DM') {
+                setIsDmSideBar(true);
                 navigate(`/workspace/${workspaceId}/dm/1`);
               }
               if (item.type === 'ETC') alert('더보기는 아직 준비중입니다!');

--- a/frontend/src/lib/clients.ts
+++ b/frontend/src/lib/clients.ts
@@ -5,5 +5,5 @@ export const chatApi = createApi(import.meta.env.VITE_BASE_CHAT_API_URL);
 export const spaceApi = createApi(import.meta.env.VITE_BASE_SPACE_API_URL);
 export const authApi = createApi(import.meta.env.VITE_BASE_AUTH_API_URL);
 export const directMessageApi = createApi(
-  import.meta.env.VITE_BASE_AUTH_API_URL
+  import.meta.env.VITE_BASE_DMS_API_URL
 );

--- a/frontend/src/pages/dm/DMPage.tsx
+++ b/frontend/src/pages/dm/DMPage.tsx
@@ -1,14 +1,17 @@
 import SplitPaneLayout from '@/components/common/SplitPaneLayout';
 import DMContent from '@/components/dm/DMContent';
 import SideBar from '@/components/dm/sideBar';
+import WorkspaceChannelPanel from '@/components/workspace/WorkspaceChannelPanel';
+import useIsDmSideBarStore from '@/stores/isDm';
 
 const DMPage = () => {
+  const { isDmSideBar } = useIsDmSideBarStore();
   return (
     <div className="flex w-full h-screen overflow-hidden">
       <SplitPaneLayout
         leftPannelDefaultSize={30}
         rightPannelDefaultSize={70}
-        children1={<SideBar />}
+        children1={isDmSideBar ? <SideBar /> : <WorkspaceChannelPanel />}
         children2={
           <div className="w-full">
             <DMContent />

--- a/frontend/src/routers/index.tsx
+++ b/frontend/src/routers/index.tsx
@@ -1,5 +1,4 @@
 import { createBrowserRouter } from 'react-router-dom';
-import DMPage from '@/pages/dm/DMPage';
 import LoginPage from '@/pages/login/LoginPage';
 import WorkspaceFrame from '@/components/frame/workspace/WorkspaceFrame';
 import ConfirmEmailPage from '@/pages/login/ConfirmEmailPage';
@@ -11,6 +10,9 @@ import WorkspaceChannelPanel from '@/components/workspace/WorkspaceChannelPanel'
 import SplitPaneLayout from '@/components/common/SplitPaneLayout';
 import NotFoundPage from '@/pages/NotFoundPage';
 import WorkspaceJoinPage from '@/pages/workspace/WorkspaceJoinPage';
+import DMContent from '@/components/dm/DMContent';
+import SideBar from '@/components/dm/sideBar';
+import DMPage from '@/pages/dm/DMPage';
 
 export const router = createBrowserRouter([
   {

--- a/frontend/src/stores/isDm.ts
+++ b/frontend/src/stores/isDm.ts
@@ -1,0 +1,12 @@
+import { create } from 'zustand';
+interface IsDmState {
+  dmId: string | null;
+  setDmId: (dmId: string | null) => void;
+}
+
+const useIsDmStore = create<IsDmState>(set => ({
+  dmId: null,
+  setDmId: dmId => set({ dmId }),
+}));
+
+export default useIsDmStore;

--- a/frontend/src/stores/isDm.ts
+++ b/frontend/src/stores/isDm.ts
@@ -1,12 +1,13 @@
 import { create } from 'zustand';
-interface IsDmState {
-  dmId: string | null;
-  setDmId: (dmId: string | null) => void;
+
+interface IsDmSideBarState {
+  isDmSideBar: boolean;
+  setIsDmSideBar: (isDmSideBar: boolean) => void;
 }
 
-const useIsDmStore = create<IsDmState>(set => ({
-  dmId: null,
-  setDmId: dmId => set({ dmId }),
+const useIsDmSideBarStore = create<IsDmSideBarState>(set => ({
+  isDmSideBar: false,
+  setIsDmSideBar: isDmSideBar => set({ isDmSideBar }),
 }));
 
-export default useIsDmStore;
+export default useIsDmSideBarStore;


### PR DESCRIPTION
## #️⃣연관된 이슈

> #209 

## 📝작업 내용

### 현재 동작
- 워크스페이스 접속 후 MainNavigationSidebar 에서 DM 리스트 항목 클릭 시
- MainNavigationSidebar 가 사라지고, DM 리스트 화면으로 대체되어 노출됨

### 기대 동작
- MainNavigationSidebar 는 그대로 유지되어야 하며
- 클릭 시 우측 채팅 패널에서 선택한 DM 채팅이 열려야 함
- WorkspaceSideBar의 DM 버튼 클릭시에 DM 리스트만 보이는 SideBar가 보여야함

### 재현 방법
1. 워크스페이스 접속
2. MainNavigationSidebar 에서 DM 리스트 목록 중 하나의 DM 클릭
3. MainNavigationSidebar 가 DM 리스트 컴포넌트로 렌더링됨

## 🧩 원인
- MainNavigationSidebar 의 상태가 DM 클릭 시 변경되어, 사이드바 자체가 DMPage 의 사이드바로 전환됨
- 사이드바와 메인 패널 간의 역할 분리가 부족하여 사이드바가 DMPage 로 교체되는 현상 발생

## 🛠️ 해결 방법
- **store 를 활용한 조건부 렌더링 적용**
  - MainNavigationSidebar 의 DM 을 클릭했을 때에만 DMPage 의 사이드바가 렌더링되도록 수정
  - DM 클릭 시 store 상태를 변경하고, 해당 상태에 따라 사이드바 컴포넌트를 조건부로 분기 렌더링
```tsx
<SplitPaneLayout
  leftPannelDefaultSize={30}
  rightPannelDefaultSize={70}
  children1={isDmSideBar ? <SideBar /> : <WorkspaceChannelPanel />}
  children2={
    <div className="w-full">
      <DMContent />
    </div>
  }
/>
```
### 스크린샷 (선택)
<img width="508" alt="스크린샷 2025-04-08 오후 1 05 24" src="https://github.com/user-attachments/assets/8cdc580e-985c-4282-9510-b775da498853" />
<img width="778" alt="스크린샷 2025-04-08 오후 1 06 13" src="https://github.com/user-attachments/assets/5360490f-bdc8-4400-890b-768beb70404c" />

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
