### PR TITLE
[BE] refactor: 채팅 메시지 정합성 보장

### DIFF
--- a/backend/chat-server/src/main/java/com/smiletogether/chatserver/config/KafkaConfig.java
+++ b/backend/chat-server/src/main/java/com/smiletogether/chatserver/config/KafkaConfig.java
@@ -1,13 +1,19 @@
 package com.smiletogether.chatserver.config;
 
+import java.util.HashMap;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
 import org.springframework.kafka.core.KafkaAdmin;
 
 import java.util.Map;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
 
 @Configuration
 public class KafkaConfig {
@@ -35,6 +41,23 @@ public class KafkaConfig {
         return new KafkaAdmin(Map.of(
                 AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers
         ));
+    }
+
+    @Bean
+    public ProducerFactory<String, String> producerFactory() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        config.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        config.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        config.put(ProducerConfig.PARTITIONER_CLASS_CONFIG, PartitionConfig.class); // ✅ custom partitioner
+
+        return new DefaultKafkaProducerFactory<>(config);
+    }
+
+
+    @Bean
+    public KafkaTemplate<String, String> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
     }
 
     @Bean

--- a/backend/chat-server/src/main/java/com/smiletogether/chatserver/config/PartitionConfig.java
+++ b/backend/chat-server/src/main/java/com/smiletogether/chatserver/config/PartitionConfig.java
@@ -1,0 +1,29 @@
+package com.smiletogether.chatserver.config;
+
+import org.apache.kafka.clients.producer.Partitioner;
+import org.apache.kafka.common.Cluster;
+
+import java.util.Map;
+
+public class PartitionConfig implements Partitioner {
+
+  @Override
+  public int partition(String topic, Object key, byte[] keyBytes, Object value, byte[] valueBytes, Cluster cluster) {
+    int numPartitions = cluster.partitionCountForTopic(topic);
+
+    // key가 null일 경우 0번 파티션으로 보냄
+    if (key == null) {
+      return 0;
+    }
+
+    // 채널 ID를 기반으로 특정 파티션을 고정 (음수 방지)
+    int partition = Math.abs(key.hashCode()) % numPartitions;
+    return partition;
+  }
+
+  @Override
+  public void close() {}
+
+  @Override
+  public void configure(Map<String, ?> configs) {}
+}

--- a/backend/chat-server/src/main/java/com/smiletogether/chatserver/service/ChatService.java
+++ b/backend/chat-server/src/main/java/com/smiletogether/chatserver/service/ChatService.java
@@ -34,9 +34,25 @@ public class ChatService {
     }
 
     private WorkspaceProfileDto initProfile(String token, String workspaceId, String userId) {
-        log.info("Initializing workspace profile");
-        return externalProfileApiClient.getWorkspaceProfile(token, workspaceId, userId);
+        log.info("Initializing workspace profile: workspaceId={}, userId={}", workspaceId, userId);
+        WorkspaceProfileDto profile = externalProfileApiClient.getWorkspaceProfile(token, workspaceId, userId);
+
+        if (profile == null) {
+            log.warn("⚠️ 프로필 불러오기 실패. 기본 프로필로 대체: workspaceId={}, userId={}", workspaceId, userId);
+
+            return new WorkspaceProfileDto(
+                userId,
+                "익명 사용자",                         // displayName
+                "https://example.com/default.png",    // profileImage
+                "미정",                                // position
+                false,                                 // isActive
+                "상태 메시지 없음"                     // statusMessage
+            );
+        }
+
+        return profile;
     }
+
 
     private ChannelMessageDto createChannelChat(String workspaceId, String channelId,
                                                 WorkspaceProfileDto senderProfile, String content) {

--- a/backend/chat-server/src/main/java/com/smiletogether/chatserver/service/producer/MessageProducer.java
+++ b/backend/chat-server/src/main/java/com/smiletogether/chatserver/service/producer/MessageProducer.java
@@ -6,7 +6,6 @@ import com.smiletogether.chatserver.dto.ChannelMessageDto;
 import com.smiletogether.chatserver.dto.ChannelMessageUpdateDto;
 import com.smiletogether.chatserver.dto.request.ChannelMessageDeleteRequest;
 import com.smiletogether.chatserver.dto.request.ChannelMessageUpdateKafkaRequest;
-import com.smiletogether.chatserver.dto.request.ChannelMessageUpdateRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.core.KafkaTemplate;
@@ -17,49 +16,53 @@ import org.springframework.stereotype.Service;
 @Slf4j
 public class MessageProducer {
 
-    private final KafkaTemplate<String, String> kafkaTemplate; // JSON을 문자열로 전송
-    private final ObjectMapper objectMapper; // 주입받도록 변경
+    private final KafkaTemplate<String, String> kafkaTemplate;
+    private final ObjectMapper objectMapper;
+
     private static final String CHAT_TOPIC = "channel-topic";
     private static final String HISTORY_TOPIC = "history-topic";
 
-    public void sendMessage(ChannelMessageDto channelMessageDto) {
+    public void sendMessage(ChannelMessageDto dto) {
         try {
-            String jsonMessage = objectMapper.writeValueAsString(channelMessageDto); // 객체 -> JSON 변환
-            log.info("Sending message to Kafka as JSON: {}", jsonMessage);
-            kafkaTemplate.send(CHAT_TOPIC, jsonMessage); // JSON 문자열로 Kafka에 전송
-            kafkaTemplate.send(HISTORY_TOPIC, jsonMessage);
+            String key = dto.channelId(); // ✅ key = channelId
+            String json = objectMapper.writeValueAsString(dto);
+
+            log.info("Kafka send (key = {}, topic = {}): {}", key, CHAT_TOPIC, json);
+            kafkaTemplate.send(CHAT_TOPIC, key, json);
+            kafkaTemplate.send(HISTORY_TOPIC, key, json);
 
         } catch (Exception e) {
-            log.error("Failed to serialize message", e);
+            log.error("❌ Failed to send message", e);
         }
     }
 
-    public void updateMessage(ChannelMessageUpdateKafkaRequest channelMessageUpdateRequest,
-                              ChannelMessageUpdateDto channelMessageUpdateDto) {
+    public void updateMessage(ChannelMessageUpdateKafkaRequest req, ChannelMessageUpdateDto dto) {
         try {
-            String jsonMessage = objectMapper.writeValueAsString(channelMessageUpdateDto); // 객체 -> JSON 변환
-            log.info("Sending message to Kafka as JSON: {}", jsonMessage);
-            kafkaTemplate.send(CHAT_TOPIC, jsonMessage);
+            String key = dto.channelId(); // ✅ 동일하게 channelId 기준
+            String jsonForChat = objectMapper.writeValueAsString(dto);
+            String jsonForHistory = objectMapper.writeValueAsString(req);
 
-            jsonMessage = objectMapper.writeValueAsString(channelMessageUpdateRequest);
-            kafkaTemplate.send(HISTORY_TOPIC, jsonMessage);
+            log.info("Kafka update (key = {}, topic = {}): {}", key, CHAT_TOPIC, jsonForChat);
+            kafkaTemplate.send(CHAT_TOPIC, key, jsonForChat);
+            kafkaTemplate.send(HISTORY_TOPIC, key, jsonForHistory);
+
         } catch (Exception e) {
-            log.error("Failed to serialize message", e);
+            log.error("❌ Failed to send update message", e);
         }
     }
 
-    public void deleteMessage(ChannelMessageDeleteRequest channelMessageDeleteRequest,
-                              ChannelMessageDeleteDto channelMessageDeleteDto) {
+    public void deleteMessage(ChannelMessageDeleteRequest req, ChannelMessageDeleteDto dto) {
         try {
-            String jsonMessage = objectMapper.writeValueAsString(channelMessageDeleteDto); // 객체 -> JSON 변환
-            log.info("Sending message to Kafka as JSON: {}", jsonMessage);
-            kafkaTemplate.send(CHAT_TOPIC, jsonMessage);
+            String key = dto.channelId(); // ✅ 역시 key 지정
+            String jsonForChat = objectMapper.writeValueAsString(dto);
+            String jsonForHistory = objectMapper.writeValueAsString(req);
 
-            jsonMessage = objectMapper.writeValueAsString(channelMessageDeleteRequest); // 객체 -> JSON 변환
-            log.info("Sending message to Kafka as JSON: {}", jsonMessage);
-            kafkaTemplate.send(HISTORY_TOPIC, jsonMessage);
+            log.info("Kafka delete (key = {}, topic = {}): {}", key, CHAT_TOPIC, jsonForChat);
+            kafkaTemplate.send(CHAT_TOPIC, key, jsonForChat);
+            kafkaTemplate.send(HISTORY_TOPIC, key, jsonForHistory);
+
         } catch (Exception e) {
-            log.error("Failed to serialize message", e);
+            log.error("❌ Failed to send delete message", e);
         }
     }
 }

--- a/backend/history-server/src/main/java/com/smiletogether/historyserver/controller/ChannelMessageController.java
+++ b/backend/history-server/src/main/java/com/smiletogether/historyserver/controller/ChannelMessageController.java
@@ -2,9 +2,10 @@ package com.smiletogether.historyserver.controller;
 
 import com.smiletogether.historyserver.infrastructure.JwtExtractor;
 import com.smiletogether.historyserver.service.ChannelMessageService;
-import com.smiletogether.historyserver.service.dto.response.ChannelMessageResponse;
 import com.smiletogether.historyserver.service.dto.ChannelMessages;
 import com.smiletogether.historyserver.service.dto.request.ChannelMessagesRequest;
+import com.smiletogether.historyserver.service.dto.response.ChannelMessageResponse;
+import com.smiletogether.historyserver.util.KafkaLagChecker;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -19,6 +20,7 @@ public class ChannelMessageController {
 
     private final ChannelMessageService channelMessageService;
     private final JwtExtractor jwtExtractor;
+    private final KafkaLagChecker kafkaLagChecker;
 
     @GetMapping("/api/workspaces/{workspaceId}/channels/{channelId}/messages")
     public ChannelMessages getMessages(
@@ -32,6 +34,11 @@ public class ChannelMessageController {
             throw new RuntimeException("Missing or invalid token");
         }
         log.info("Extracted token: {}", token);
+
+        if (!kafkaLagChecker.waitUntilPartitionSynced("history-topic", "history-server-group", channelId, 5, 100)) {
+            log.error("Kafka offset lag timeout – 메시지가 너무 늦게 소비됨");
+        }
+
         return channelMessageService.getChannelMessages(channelMessagesRequest, workspaceId, channelId, token);
     }
 

--- a/backend/history-server/src/main/java/com/smiletogether/historyserver/service/KafkaConsumerService.java
+++ b/backend/history-server/src/main/java/com/smiletogether/historyserver/service/KafkaConsumerService.java
@@ -2,12 +2,13 @@ package com.smiletogether.historyserver.service;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.smiletogether.historyserver.service.dto.request.ChannelMessageDeleteRequest;
 import com.smiletogether.historyserver.service.dto.ChannelMessageReaction;
+import com.smiletogether.historyserver.service.dto.request.ChannelMessageDeleteRequest;
 import com.smiletogether.historyserver.service.dto.request.ChannelMessageSaveRequest;
 import com.smiletogether.historyserver.service.dto.request.ChannelMessageUpdateRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Service;
 
@@ -15,62 +16,74 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 @Slf4j
 public class KafkaConsumerService {
+
     private final ObjectMapper objectMapper;
     private final ChannelMessageService channelMessageService;
 
     @KafkaListener(topics = "history-topic", groupId = "history-server-group")
-    public void consumeChannelMessage(String messageJson) {
+    public void consumeChannelMessage(ConsumerRecord<String, String> record) {
+        String messageJson = record.value();
+
+        log.info("[Kafka][history-topic] partition: {}, offset: {}, key: {}, topic: {}",
+                record.partition(), record.offset(), record.key(), record.topic());
+        log.info("Raw message: {}", messageJson);
+
         try {
             JsonNode jsonNode = objectMapper.readTree(messageJson);
             String type = jsonNode.get("type").asText();
-            log.info("Received channel message: {}", messageJson);
 
             switch (type) {
-                case "SEND":
-                    ChannelMessageSaveRequest saveRequest = objectMapper.readValue(messageJson, ChannelMessageSaveRequest.class);
+                case "SEND" -> {
+                    ChannelMessageSaveRequest saveRequest = objectMapper.readValue(messageJson,
+                            ChannelMessageSaveRequest.class);
                     channelMessageService.saveMessage(saveRequest);
-                    log.info("Kafka: 메시지 저장 성공");
-                    break;
-
-                case "UPDATE":
-                    ChannelMessageUpdateRequest updateRequest = objectMapper.readValue(messageJson, ChannelMessageUpdateRequest.class);
+                    log.info("Message saved (messageId: {})",
+                            saveRequest.messageId());
+                }
+                case "UPDATE" -> {
+                    ChannelMessageUpdateRequest updateRequest = objectMapper.readValue(messageJson,
+                            ChannelMessageUpdateRequest.class);
                     channelMessageService.updateChannelMessage(updateRequest);
-                    log.info("Kafka: 메시지 업데이트 성공");
-                    break;
-
-                case "DELETE":
-                    ChannelMessageDeleteRequest deleteRequest = objectMapper.readValue(messageJson, ChannelMessageDeleteRequest.class);
+                    log.info("Message updated (messageId: {})",
+                            updateRequest.messageId());
+                }
+                case "DELETE" -> {
+                    ChannelMessageDeleteRequest deleteRequest = objectMapper.readValue(messageJson,
+                            ChannelMessageDeleteRequest.class);
                     channelMessageService.deleteChannelMessage(deleteRequest);
-                    log.info("Kafka: 메시지 삭제 성공");
-                    break;
-
-                default:
-                    log.warn("⚠Kafka: 알 수 없는 메시지 타입: {}", type);
+                    log.info("Message deleted (messageId: {})",
+                            deleteRequest.messageId());
+                }
+                default -> log.warn("Unknown message type: {}", type);
             }
         } catch (Exception e) {
-            log.error("Kafka: 메시지 처리 실패", e);
+            log.error("Failed to process message: {}", messageJson, e);
         }
     }
 
-
     @KafkaListener(topics = "channel-message-reaction", groupId = "history-group")
-    public void consumeEmojiReaction(String messageJson) {
+    public void consumeEmojiReaction(ConsumerRecord<String, String> record) {
+        String messageJson = record.value();
+
+        log.info("[Kafka][reaction-topic] partition: {}, offset: {}, key: {}, topic: {}",
+                record.partition(), record.offset(), record.key(), record.topic());
+        log.info("Raw reaction message: {}", messageJson);
+
         try {
-            ChannelMessageReaction channelMessageReaction = objectMapper.readValue(messageJson, ChannelMessageReaction.class);
+            ChannelMessageReaction reaction = objectMapper.readValue(messageJson, ChannelMessageReaction.class);
+            String type = reaction.type();
 
-            String type = channelMessageReaction.type();
-            if (type.equals("CREATE")) {
-                channelMessageService.createChannelMessageReaction(channelMessageReaction);
-                log.info("성공");
+            switch (type) {
+                case "CREATE" -> {
+                    channelMessageService.createChannelMessageReaction(reaction);
+                }
+                case "DELETE" -> {
+                    channelMessageService.deleteChannelMessageReaction(reaction);
+                }
+                default -> log.warn("Unknown reaction type: {}", type);
             }
-
-            if (type.equals("DELETE")) {
-                channelMessageService.deleteChannelMessageReaction(channelMessageReaction);
-                log.info("성공");
-            }
-
         } catch (Exception e) {
-            log.error("Failed to deserialize Kafka message", e);
+            log.error("Failed to process reaction message: {}", messageJson, e);
         }
     }
 }

--- a/backend/history-server/src/main/java/com/smiletogether/historyserver/util/KafkaLagChecker.java
+++ b/backend/history-server/src/main/java/com/smiletogether/historyserver/util/KafkaLagChecker.java
@@ -1,0 +1,56 @@
+package com.smiletogether.historyserver.util;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.stereotype.Component;
+import org.apache.kafka.common.TopicPartition;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class KafkaLagChecker {
+
+    private final ConsumerFactory<String, String> consumerFactory;
+
+    public boolean isPartitionUpToDate(String topic, String groupId, String channelId) {
+        try (Consumer<String, String> consumer = consumerFactory.createConsumer(groupId)) {
+
+            int partition = calculatePartition(topic, channelId, consumer);
+            TopicPartition topicPartition = new TopicPartition(topic, partition);
+
+            consumer.assign(List.of(topicPartition));
+            consumer.seekToEnd(List.of(topicPartition));  // 최신 오프셋 위치로 이동
+
+            long latestOffset = consumer.position(topicPartition);
+
+            consumer.seekToBeginning(List.of(topicPartition)); // 커밋된 위치 확인
+            long committedOffset = consumer.committed(topicPartition).offset();
+
+            log.info("[KafkaLag] channelId={}, partition={}, committed={}, latest={}",
+                    channelId, partition, committedOffset, latestOffset);
+
+            return committedOffset >= latestOffset;
+        } catch (Exception e) {
+            log.error("Kafka lag 확인 중 오류", e);
+            return false;
+        }
+    }
+
+    private int calculatePartition(String topic, String channelId, Consumer<String, String> consumer) {
+        int partitionCount = consumer.partitionsFor(topic).size();
+        return Math.abs(channelId.hashCode()) % partitionCount;
+    }
+
+    public boolean waitUntilPartitionSynced(String topic, String groupId, String channelId, int maxRetry, long delayMillis) {
+        for (int i = 0; i < maxRetry; i++) {
+            if (isPartitionUpToDate(topic, groupId, channelId)) return true;
+            try {
+                Thread.sleep(delayMillis);
+            } catch (InterruptedException ignored) {}
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

#220 

## 📝작업 내용
- [x] `GET /api/workspaces/{workspaceId}/channels/{channelId}/messages` 요청 시 Kafka offset lag 확인 후 메시지 응답하도록 수정
- [x] KafkaLagChecker 유틸 클래스 생성: 파티션 오프셋을 조회해 현재 커밋된 offset과 latest offset을 비교
- [x] lag이 존재하면 최대 5회, 100ms 간격으로 polling 하여 consume 완료 여부 확인
- [x] 정합성이 보장된 이후 DB에서 메시지를 조회하여 응답
- [x] 메시지 조회 시점 기준의 데이터 일관성 확보 (SEND 메시지에만 적용)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
다음과 같은 플로우로 작동됩니다.

[1] 히스토리 조회 요청 들어옴
       ↓
[2] 이 채널에 해당하는 파티션 lag 있는지 확인
       ↓
[3] lag > 0이면 → poll 하면서 기다림 (ex. 100ms * 5회)
       ↓
[4] lag == 0이면 → DB 조회 → 응답
