### PR TITLE
[BE] fix : 워크스페이스 생성 시 이메일 전송

### DIFF
--- a/backend/space-server/package.json
+++ b/backend/space-server/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "license": "UNLICENSED",
   "scripts": {
-    "build": "nest build",
+    "build": "npx prisma migrate deploy && npx prisma generate && nest build",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "start": "nest start",
     "start:dev": "nest start --watch",

--- a/backend/space-server/src/workspace/workspace.service.ts
+++ b/backend/space-server/src/workspace/workspace.service.ts
@@ -13,7 +13,6 @@ import { WorkspaceDetailResponseDto } from './dto/workspace-detail.dto';
 import { WorkspaceDeleteResponseDto } from './dto/delete-workspace.dto';
 import { InviteWorkspaceDto } from './dto/invite-workspace.dto';
 import { ProfileResponseDto } from 'src/common/dto/profile-response.dto';
-import { isUUID } from 'class-validator';
 
 @Injectable()
 export class WorkspaceService {
@@ -173,55 +172,25 @@ export class WorkspaceService {
         const newUserId = await this.getUserIdByEmail(email);
         const newUserNickName = await this.getNameByUserId(newUserId);
         console.log(newUserId, newUserNickName);
-        if (isUUID(newUserId)) {
-          try {
-            // 워크스페이스 멤버로 추가
-            await prisma.workspaceUser.create({
-              data: {
-                workspace_id: workspace.workspace_id,
-                user_id: newUserId,
-                role: 'member',
-                profile_name: newUserNickName,
-                profile_image: 'default.jpg',
-                position: '',
-                status_message: '',
-              },
-            });
 
-            // 기본 채널에 추가
-            await prisma.channelUser.create({
-              data: {
-                channel_id: defaultChannel.channel_id,
-                user_id: newUserId,
-                channel_role: 'member',
-              },
-            });
+        // 초대 링크 전송송
+        try {
+          const domain = 'http://localhost:5173';
+          const { inviteResults: emailInviteResults } =
+            await this.inviteService.generateEmailInvites(
+              domain,
+              [email],
+              workspace.workspace_id,
+            );
 
+          if (emailInviteResults.success.includes(email)) {
             inviteResults.success.push(email);
-          } catch (error) {
-            console.log(`Failed to invite user ${email}:`, error);
+          } else {
             inviteResults.failed.push(email);
           }
-        } else {
-          // 가입되지 않은 이메일의 경우 초대 링크 보내기
-          try {
-            const domain = 'http://localhost:5173';
-            const { inviteResults: emailInviteResults } =
-              await this.inviteService.generateEmailInvites(
-                domain,
-                [email],
-                workspace.workspace_id,
-              );
-
-            if (emailInviteResults.success.includes(email)) {
-              inviteResults.success.push(email);
-            } else {
-              inviteResults.failed.push(email);
-            }
-          } catch (error) {
-            console.log(`Failed to send invite link to ${email}:`, error);
-            inviteResults.failed.push(email);
-          }
+        } catch (error) {
+          console.log(`Failed to send invite link to ${email}:`, error);
+          inviteResults.failed.push(email);
         }
       }
 

--- a/backend/space-server/src/workspace/workspace.service.ts
+++ b/backend/space-server/src/workspace/workspace.service.ts
@@ -203,14 +203,25 @@ export class WorkspaceService {
             inviteResults.failed.push(email);
           }
         } else {
-          console.log(
-            '해당 이메일로 조회된 userId가 올바르지 않습니다.',
-            '조회 한 userEmail: ',
-            email,
-            '조회 된 userId: ',
-            newUserId,
-          );
-          inviteResults.failed.push(email);
+          // 가입되지 않은 이메일의 경우 초대 링크 보내기
+          try {
+            const domain = 'http://localhost:5173';
+            const { inviteResults: emailInviteResults } =
+              await this.inviteService.generateEmailInvites(
+                domain,
+                [email],
+                workspace.workspace_id,
+              );
+
+            if (emailInviteResults.success.includes(email)) {
+              inviteResults.success.push(email);
+            } else {
+              inviteResults.failed.push(email);
+            }
+          } catch (error) {
+            console.log(`Failed to send invite link to ${email}:`, error);
+            inviteResults.failed.push(email);
+          }
         }
       }
 

--- a/backend/space-server/tsconfig.build.json
+++ b/backend/space-server/tsconfig.build.json
@@ -1,4 +1,5 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]
+  "exclude": ["node_modules", "test", "dist", "**/*spec.ts"],
+  "include": ["src/**/*"]
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> - #219 

## 📝작업 내용

> 작업한 내용을 작성해주세요.

워크스페이스 초대 시 이메일 입력하면 초대 메일 발송

### 스크린샷 (선택)

![워크스페이스 생성](https://github.com/user-attachments/assets/49f90105-87e2-441b-9fee-baf6abf18406)
inviteEmailList에 이메일 추가

![워크스페이스 생성 시 초대 이메일](https://github.com/user-attachments/assets/f6d927b4-05a2-4109-96e8-babb64312da3)
이메일 전송

![워크스페이스 생성 시 이메일 초대 후 워크스페이스 아이디 조회 시 수락 대기 중으로 뜸](https://github.com/user-attachments/assets/795bc1cf-48ec-40d8-899e-a58a1d1e8d8e)
이메일 초대 후 워크스페이스 조회 시 -> pending_invites로 뜸


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
